### PR TITLE
Fix full-width browser layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -109,12 +109,12 @@ body::before {
 }
 
 .app-shell {
-  width: min(1360px, calc(100% - 32px));
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  padding: 18px 0 16px;
+  padding: 18px 16px 16px;
   overflow: hidden;
 }
 
@@ -1080,9 +1080,10 @@ h1 {
 
 @media (max-width: 640px) {
   .app-shell {
-    width: min(100% - 20px, 1360px);
     padding-top: 20px;
     padding-bottom: 16px;
+    padding-left: 10px;
+    padding-right: 10px;
   }
 
   .panel-header,


### PR DESCRIPTION
## Summary
- remove the desktop max-width cap from the main app shell
- preserve horizontal gutters by moving them into shell padding
- keep tighter mobile side padding in the small-screen breakpoint

Closes #9