### PR TITLE
Add manual sync link in save status

### DIFF
--- a/app.js
+++ b/app.js
@@ -717,11 +717,13 @@ const buildCloudStatusText = () => {
 
 const buildSaveStatusText = (savedAt = new Date(), syncedAt = cloudSyncSettings.lastSyncAt) => {
   const localLabel = `Saved locally ${new Date(savedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
-  const syncLabel = cloudSyncSettings.lastError
-    ? `Sync failed: ${cloudSyncSettings.lastError}`
-    : syncedAt
-      ? `Synced ${new Date(syncedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
-      : "Not synced yet";
+  const syncLabel = cloudSyncSettings.status.startsWith("Syncing")
+    ? "Syncing ..."
+    : cloudSyncSettings.lastError
+      ? `Sync failed: ${cloudSyncSettings.lastError}`
+      : syncedAt
+        ? `Synced ${new Date(syncedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+        : "Not synced yet";
 
   return { localLabel, syncLabel };
 };
@@ -1001,6 +1003,7 @@ const syncWorkspaceToCloud = async ({ reason = "manual" } = {}) => {
       cloudSyncSettings.lastError = "";
       persistCloudSyncSettings();
       renderSettings();
+      refreshSaveStatus();
 
       const result = await activeProvider.upload(buildCloudSyncPayload(), getActiveProviderSettings());
 

--- a/app.js
+++ b/app.js
@@ -620,7 +620,25 @@ const persistWorkspace = () => {
 };
 
 const updateSaveStatus = (message) => {
-  saveStatus.textContent = message;
+  saveStatus.replaceChildren();
+
+  if (typeof message === "string") {
+    saveStatus.textContent = message;
+    return;
+  }
+
+  const { localLabel, syncLabel } = message;
+
+  const localText = document.createTextNode(`${localLabel} • `);
+  const syncButton = document.createElement("button");
+  syncButton.type = "button";
+  syncButton.className = "save-status-sync";
+  syncButton.textContent = syncLabel;
+  syncButton.addEventListener("click", async () => {
+    await syncWorkspaceToCloud({ reason: "manual" });
+  });
+
+  saveStatus.append(localText, syncButton);
 };
 
 const persistCloudSyncSettings = () => {
@@ -705,7 +723,7 @@ const buildSaveStatusText = (savedAt = new Date(), syncedAt = cloudSyncSettings.
       ? `Synced ${new Date(syncedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
       : "Not synced yet";
 
-  return `${localLabel} • ${syncLabel}`;
+  return { localLabel, syncLabel };
 };
 
 const refreshSaveStatus = () => {

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
         ></div>
 
         <div class="panel-footer">
-          <p id="save-status">Saved locally just now • Not synced to cloud yet</p>
+          <p id="save-status" class="save-status"></p>
         </div>
       </section>
 

--- a/styles.css
+++ b/styles.css
@@ -611,6 +611,30 @@ h1 {
   font-size: 0.92rem;
 }
 
+.save-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.save-status-sync {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+}
+
+.save-status-sync:hover,
+.save-status-sync:focus-visible {
+  color: var(--accent-strong);
+  outline: none;
+}
+
 .note-editor h2 {
   font-size: 1.55rem;
   margin-bottom: 0.25em;

--- a/styles.css
+++ b/styles.css
@@ -622,16 +622,16 @@ h1 {
   border: 0;
   padding: 0;
   background: none;
-  color: var(--accent);
+  color: var(--muted);
   font: inherit;
   cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 0.14em;
+  text-decoration: none;
 }
 
 .save-status-sync:hover,
 .save-status-sync:focus-visible {
-  color: var(--accent-strong);
+  color: var(--muted);
+  opacity: 0.82;
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- turn the cloud sync portion of the footer status into a clickable manual sync action
- preserve one-off plain status messages during legacy note migration
- style the footer action like an inline link while keeping the existing sync text state

Closes #12