### PR TITLE
Split cloud sync into settings and per-note files

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,7 +132,8 @@ const workspace = {
   notes: [],
   activeNoteId: null,
   selectedNewNoteTypeId: null,
-  customBookAliases: {}
+  customBookAliases: {},
+  updatedAt: null
 };
 
 const settingsTabs = [
@@ -300,7 +301,10 @@ const cloudSyncSettings = {
   pollIntervalSeconds: 60,
   status: "Not connected",
   lastSyncAt: null,
+  localSettingsUpdatedAt: null,
   connectedEmail: "",
+  remoteSettingsFileId: "",
+  remoteNoteFileIds: {},
   remoteWorkspaceFileId: "",
   remoteWorkspaceParentId: "",
   lastError: "",
@@ -312,7 +316,12 @@ const normalizeCloudSyncSettings = (value = {}) => ({
   pollIntervalSeconds: Number(value.pollIntervalSeconds) || 60,
   status: typeof value.status === "string" && value.status ? value.status : "Not connected",
   lastSyncAt: typeof value.lastSyncAt === "string" ? value.lastSyncAt : null,
+  localSettingsUpdatedAt: typeof value.localSettingsUpdatedAt === "string" ? value.localSettingsUpdatedAt : null,
   connectedEmail: typeof value.connectedEmail === "string" ? value.connectedEmail : "",
+  remoteSettingsFileId: typeof value.remoteSettingsFileId === "string" ? value.remoteSettingsFileId : "",
+  remoteNoteFileIds: value.remoteNoteFileIds && typeof value.remoteNoteFileIds === "object" && !Array.isArray(value.remoteNoteFileIds)
+    ? value.remoteNoteFileIds
+    : {},
   remoteWorkspaceFileId: typeof value.remoteWorkspaceFileId === "string" ? value.remoteWorkspaceFileId : "",
   remoteWorkspaceParentId: typeof value.remoteWorkspaceParentId === "string" ? value.remoteWorkspaceParentId : "",
   lastError: typeof value.lastError === "string" ? value.lastError : "",
@@ -611,10 +620,13 @@ const ensureWorkspaceConsistency = () => {
         ])
       )
     : {};
+
+  workspace.updatedAt = typeof workspace.updatedAt === "string" ? workspace.updatedAt : null;
 };
 
 const persistWorkspace = () => {
   ensureWorkspaceConsistency();
+  workspace.updatedAt = new Date().toISOString();
   void writeStoredValue(workspaceStorageKey, structuredClone(workspace));
   scheduleAutoCloudSync();
 };
@@ -625,6 +637,11 @@ const updateSaveStatus = (message) => {
 
 const persistCloudSyncSettings = () => {
   void writeStoredValue(cloudSyncStorageKey, structuredClone(cloudSyncSettings));
+};
+
+const markLocalSettingsUpdated = () => {
+  cloudSyncSettings.localSettingsUpdatedAt = new Date().toISOString();
+  persistCloudSyncSettings();
 };
 
 const resetTransientCloudSessionState = () => {
@@ -714,24 +731,10 @@ const refreshSaveStatus = () => {
   updateSaveStatus(buildSaveStatusText(savedAt));
 };
 
-const buildCloudSyncPayload = () => ({
-  version: 1,
-  updatedAt: new Date().toISOString(),
-  workspace: structuredClone(workspace),
-  preferences: {
-    theme: document.documentElement.dataset.theme === "dark" ? "dark" : "light",
-    paneOrder: paneGrid.dataset.order === "scripture-first" ? "scripture-first" : "notes-first",
-    translation: currentTranslationCode,
-    colorTheme: currentColorThemeId
-  },
-  syncSettings: {
-    provider: cloudSyncSettings.provider,
-    pollIntervalSeconds: cloudSyncSettings.pollIntervalSeconds
-  }
-});
-
 const getActiveProviderSettings = () => ({
   ...cloudSyncSettings.providerSettings[activeProvider.id],
+  remoteSettingsFileId: cloudSyncSettings.remoteSettingsFileId,
+  remoteNoteFileIds: structuredClone(cloudSyncSettings.remoteNoteFileIds),
   remoteWorkspaceFileId: cloudSyncSettings.remoteWorkspaceFileId,
   remoteWorkspaceParentId: cloudSyncSettings.remoteWorkspaceParentId
 });
@@ -744,9 +747,55 @@ const buildProviderStatusLabel = () => {
   return suffix ? `${activeProvider.displayName} (${suffix})` : activeProvider.displayName;
 };
 
+const buildCloudSettingsPayload = (updatedAt = new Date().toISOString()) => ({
+  version: 2,
+  updatedAt,
+  workspace: {
+    noteTypes: structuredClone(workspace.noteTypes),
+    activeNoteId: workspace.activeNoteId,
+    selectedNewNoteTypeId: workspace.selectedNewNoteTypeId,
+    customBookAliases: structuredClone(workspace.customBookAliases),
+    updatedAt: workspace.updatedAt ?? updatedAt
+  },
+  preferences: {
+    theme: document.documentElement.dataset.theme === "dark" ? "dark" : "light",
+    paneOrder: paneGrid.dataset.order === "scripture-first" ? "scripture-first" : "notes-first",
+    translation: currentTranslationCode,
+    colorTheme: currentColorThemeId
+  },
+  syncSettings: {
+    provider: cloudSyncSettings.provider,
+    pollIntervalSeconds: cloudSyncSettings.pollIntervalSeconds
+  }
+});
+
+const buildCloudNotesPayload = (updatedAt = new Date().toISOString()) => ({
+  version: 2,
+  updatedAt,
+  notes: structuredClone(workspace.notes)
+});
+
+const buildCloudSyncPayload = () => {
+  const updatedAt = new Date().toISOString();
+
+  return {
+    updatedAt,
+    settings: buildCloudSettingsPayload(updatedAt),
+    notes: buildCloudNotesPayload(updatedAt)
+  };
+};
+
 const applyCloudPayload = (payload) => {
   if (payload.workspace) {
-    Object.assign(workspace, payload.workspace);
+    workspace.noteTypes = payload.workspace.noteTypes;
+    workspace.activeNoteId = payload.workspace.activeNoteId;
+    workspace.selectedNewNoteTypeId = payload.workspace.selectedNewNoteTypeId;
+    workspace.customBookAliases = payload.workspace.customBookAliases ?? {};
+    workspace.updatedAt = payload.workspace.updatedAt ?? payload.updatedAt ?? new Date().toISOString();
+  }
+
+  if (Array.isArray(payload.notes)) {
+    workspace.notes = payload.notes;
   }
 
   if (payload.preferences) {
@@ -780,14 +829,21 @@ const applyCloudPayload = (payload) => {
 const hasLocalNoteData = () =>
   workspace.notes.some((note) => note.content || Object.values(note.metadata).some(Boolean));
 
+const hasLocalCloudData = () =>
+  Boolean(cloudSyncSettings.localSettingsUpdatedAt || workspace.updatedAt || hasLocalNoteData());
+
 const hasLocalChangesSinceLastSync = () => {
   if (!cloudSyncSettings.lastSyncAt) {
-    return hasLocalNoteData();
+    return hasLocalCloudData();
   }
 
   const lastSync = new Date(cloudSyncSettings.lastSyncAt);
 
-  return workspace.notes.some((note) => new Date(note.updatedAt) > lastSync);
+  return Boolean(
+    (cloudSyncSettings.localSettingsUpdatedAt && new Date(cloudSyncSettings.localSettingsUpdatedAt) > lastSync) ||
+    (workspace.updatedAt && new Date(workspace.updatedAt) > lastSync) ||
+    workspace.notes.some((note) => new Date(note.updatedAt) > lastSync)
+  );
 };
 
 const showSyncConflictDialog = (remotePayload) => new Promise((resolve) => {
@@ -858,8 +914,12 @@ const pullFromCloud = async () => {
   try {
     const result = await activeProvider.download(getActiveProviderSettings());
 
-    if (result.remoteWorkspaceFileId !== cloudSyncSettings.remoteWorkspaceFileId ||
+    if (result.remoteSettingsFileId !== cloudSyncSettings.remoteSettingsFileId ||
+        JSON.stringify(result.remoteNoteFileIds ?? {}) !== JSON.stringify(cloudSyncSettings.remoteNoteFileIds) ||
+        result.remoteWorkspaceFileId !== cloudSyncSettings.remoteWorkspaceFileId ||
         result.remoteWorkspaceParentId !== cloudSyncSettings.remoteWorkspaceParentId) {
+      cloudSyncSettings.remoteSettingsFileId = result.remoteSettingsFileId;
+      cloudSyncSettings.remoteNoteFileIds = result.remoteNoteFileIds ?? {};
       cloudSyncSettings.remoteWorkspaceFileId = result.remoteWorkspaceFileId;
       cloudSyncSettings.remoteWorkspaceParentId = result.remoteWorkspaceParentId;
       persistCloudSyncSettings();
@@ -870,7 +930,7 @@ const pullFromCloud = async () => {
     if (!remotePayload) {
       console.log("[CloudSync] No remote file found.");
 
-      if (hasLocalNoteData()) {
+      if (hasLocalCloudData()) {
         console.log("[CloudSync] Local data exists with no cloud copy; triggering initial upload.");
         void syncWorkspaceToCloud({ reason: "initial" });
       } else {
@@ -897,7 +957,7 @@ const pullFromCloud = async () => {
     let resolution;
 
     if (!lastSyncAt) {
-      const hasData = hasLocalNoteData();
+      const hasData = hasLocalCloudData();
       console.log(`[CloudSync] First sync — local has data: ${hasData}. ${hasData ? "Showing conflict dialog." : "Auto-applying remote."}`);
       resolution = hasData ? await showSyncConflictDialog(remotePayload) : "remote";
     } else if (localHasChanges) {
@@ -915,8 +975,10 @@ const pullFromCloud = async () => {
 
       if (remotePayload.updatedAt) {
         cloudSyncSettings.lastSyncAt = remotePayload.updatedAt;
+        cloudSyncSettings.localSettingsUpdatedAt = remotePayload.updatedAt;
       } else {
         console.warn("[CloudSync] Remote payload is missing updatedAt timestamp; unable to update last sync time. Sync state may be inconsistent.");
+        cloudSyncSettings.localSettingsUpdatedAt = new Date().toISOString();
       }
 
       cloudSyncSettings.lastError = "";
@@ -983,12 +1045,16 @@ const syncWorkspaceToCloud = async ({ reason = "manual" } = {}) => {
       cloudSyncSettings.lastError = "";
       persistCloudSyncSettings();
       renderSettings();
+      refreshSaveStatus();
 
       const result = await activeProvider.upload(buildCloudSyncPayload(), getActiveProviderSettings());
 
+      cloudSyncSettings.remoteSettingsFileId = result.remoteSettingsFileId;
+      cloudSyncSettings.remoteNoteFileIds = result.remoteNoteFileIds ?? {};
       cloudSyncSettings.remoteWorkspaceFileId = result.remoteWorkspaceFileId;
       cloudSyncSettings.remoteWorkspaceParentId = result.remoteWorkspaceParentId;
       cloudSyncSettings.lastSyncAt = new Date().toISOString();
+      cloudSyncSettings.localSettingsUpdatedAt = cloudSyncSettings.lastSyncAt;
       cloudSyncSettings.status = `Connected to ${buildProviderStatusLabel()}`;
       cloudSyncSettings.lastError = "";
       persistCloudSyncSettings();
@@ -1153,6 +1219,7 @@ const restoreWorkspace = async () => {
     workspace.activeNoteId = savedWorkspace.activeNoteId;
     workspace.selectedNewNoteTypeId = savedWorkspace.selectedNewNoteTypeId;
     workspace.customBookAliases = savedWorkspace.customBookAliases ?? {};
+    workspace.updatedAt = savedWorkspace.updatedAt ?? null;
   } else if (savedNotes || legacyNotes) {
     migrateLegacyNotes(savedNotes ?? null, legacyNotes);
     updateSaveStatus("Converted your existing notes into typed notes.");
@@ -1217,6 +1284,7 @@ const toggleTheme = () => {
   const nextTheme = currentTheme === "dark" ? "light" : "dark";
   void writeStoredValue(themeStorageKey, nextTheme);
   applyTheme(nextTheme);
+  markLocalSettingsUpdated();
   scheduleAutoCloudSync();
 };
 
@@ -1244,6 +1312,7 @@ const togglePaneOrder = () => {
   const nextOrder = currentOrder === "scripture-first" ? "notes-first" : "scripture-first";
   void writeStoredValue(paneOrderStorageKey, nextOrder);
   applyPaneOrder(nextOrder);
+  markLocalSettingsUpdated();
   scheduleAutoCloudSync();
 };
 
@@ -2328,6 +2397,7 @@ const renderUiSettings = (container) => {
     card.addEventListener("click", () => {
       void writeStoredValue(colorThemeStorageKey, theme.id);
       applyColorTheme(theme.id);
+      markLocalSettingsUpdated();
       scheduleAutoCloudSync();
     });
     themeGrid.append(card);
@@ -2936,6 +3006,7 @@ translationSelect.addEventListener("change", () => {
   activeScriptureFocus = null;
   void writeStoredValue(translationStorageKey, translationSelect.value);
   applyTranslation(translationSelect.value);
+  markLocalSettingsUpdated();
   scheduleAutoCloudSync();
 });
 
@@ -3053,6 +3124,8 @@ cloudProviderSelect.addEventListener("change", () => {
   activeProvider = providerRegistry[newProviderId] ?? noOpProvider;
 
   // Remote file/folder IDs are provider-specific and must not carry over between providers.
+  cloudSyncSettings.remoteSettingsFileId = "";
+  cloudSyncSettings.remoteNoteFileIds = {};
   cloudSyncSettings.remoteWorkspaceFileId = "";
   cloudSyncSettings.remoteWorkspaceParentId = "";
 
@@ -3078,6 +3151,7 @@ cloudProviderSelect.addEventListener("change", () => {
 cloudPollIntervalSelect.addEventListener("change", () => {
   cloudSyncSettings.pollIntervalSeconds = Number(cloudPollIntervalSelect.value);
   persistCloudSyncSettings();
+  markLocalSettingsUpdated();
   scheduleAutoCloudSync();
   startCloudPolling();
 });
@@ -3090,6 +3164,8 @@ const handleProviderSettingChange = (key, value) => {
   const result = activeProvider.applySettingChange(key, value);
 
   if (result?.clearRemoteState) {
+    cloudSyncSettings.remoteSettingsFileId = "";
+    cloudSyncSettings.remoteNoteFileIds = {};
     cloudSyncSettings.remoteWorkspaceFileId = "";
     cloudSyncSettings.remoteWorkspaceParentId = "";
     cloudSyncSettings.lastError = "";

--- a/app.js
+++ b/app.js
@@ -632,7 +632,25 @@ const persistWorkspace = () => {
 };
 
 const updateSaveStatus = (message) => {
-  saveStatus.textContent = message;
+  saveStatus.replaceChildren();
+
+  if (typeof message === "string") {
+    saveStatus.textContent = message;
+    return;
+  }
+
+  const { localLabel, syncLabel } = message;
+
+  const localText = document.createTextNode(`${localLabel} • `);
+  const syncButton = document.createElement("button");
+  syncButton.type = "button";
+  syncButton.className = "save-status-sync";
+  syncButton.textContent = syncLabel;
+  syncButton.addEventListener("click", async () => {
+    await syncWorkspaceToCloud({ reason: "manual" });
+  });
+
+  saveStatus.append(localText, syncButton);
 };
 
 const persistCloudSyncSettings = () => {
@@ -716,13 +734,15 @@ const buildCloudStatusText = () => {
 
 const buildSaveStatusText = (savedAt = new Date(), syncedAt = cloudSyncSettings.lastSyncAt) => {
   const localLabel = `Saved locally ${new Date(savedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`;
-  const syncLabel = cloudSyncSettings.lastError
-    ? `Sync failed: ${cloudSyncSettings.lastError}`
-    : syncedAt
-      ? `Synced ${new Date(syncedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
-      : "Not synced yet";
+  const syncLabel = cloudSyncSettings.status.startsWith("Syncing")
+    ? "Syncing ..."
+    : cloudSyncSettings.lastError
+      ? `Sync failed: ${cloudSyncSettings.lastError}`
+      : syncedAt
+        ? `Synced ${new Date(syncedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+        : "Not synced yet";
 
-  return `${localLabel} • ${syncLabel}`;
+  return { localLabel, syncLabel };
 };
 
 const refreshSaveStatus = () => {

--- a/gdrive.js
+++ b/gdrive.js
@@ -69,25 +69,31 @@
  *     Returns an empty string when no extra label is needed.
  *
  *   upload(payload: object, settings: ProviderSettings): Promise<ProviderResult>
- *     Saves payload to the remote workspace file.
+ *     Saves payload to one remote settings file plus one remote file per note.
  *     Returns the (possibly updated) file/folder identifiers.
  *
  *   download(settings: ProviderSettings): Promise<{ data: object | null } & ProviderResult>
- *     Fetches the remote workspace file.
+ *     Fetches the remote settings file and all remote note files.
  *     Returns the parsed data (null if no file exists yet) and the identifiers.
  *
  * ProviderSettings:
  *   [providerKey: string]: unknown  — provider-specific settings (from getSettingsValues)
- *   remoteWorkspaceFileId: string   — cached file ID (empty string if unknown)
+ *   remoteSettingsFileId: string    — cached settings file ID (empty string if unknown)
+ *   remoteNoteFileIds: Record<string, string> — cached note file IDs by note ID
+ *   remoteWorkspaceFileId: string   — unused legacy field
  *   remoteWorkspaceParentId: string — cached parent folder ID (empty string if unknown)
  *
  * ProviderResult:
+ *   remoteSettingsFileId: string
+ *   remoteNoteFileIds: Record<string, string>
  *   remoteWorkspaceFileId: string
  *   remoteWorkspaceParentId: string
  */
 (() => {
   const clientId = "711830335817-2enpiqrmso0sqgq2fnh8o4ef4r60ede0.apps.googleusercontent.com";
-  const workspaceFileName = "churchscribe-workspace.json";
+  const settingsFileName = "churchscribe-settings.json";
+  const noteFilePrefix = "churchscribe-note-";
+  const noteFileSuffix = ".json";
   const scopes = "https://www.googleapis.com/auth/drive.appdata";
 
   let tokenClient = null;
@@ -162,22 +168,43 @@
   const resolveLocation = () => ({
     spaces: "appDataFolder",
     parents: ["appDataFolder"],
-    query: `name='${workspaceFileName}' and 'appDataFolder' in parents and trashed=false`,
     remoteWorkspaceParentId: ""
   });
 
-  const findWorkspaceFileId = async (cachedFileId, location) => {
+  const getNoteFileName = (noteId) => `${noteFilePrefix}${noteId}${noteFileSuffix}`;
+
+  const getNoteIdFromFileName = (fileName) =>
+    fileName.startsWith(noteFilePrefix) && fileName.endsWith(noteFileSuffix)
+      ? fileName.slice(noteFilePrefix.length, -noteFileSuffix.length)
+      : "";
+
+  const findFileId = async (cachedFileId, location, query) => {
     if (cachedFileId) {
       return cachedFileId;
     }
 
-    const query = encodeURIComponent(location.query);
+    const encodedQuery = encodeURIComponent(query);
     const response = await apiFetch(
-      `https://www.googleapis.com/drive/v3/files?q=${query}&spaces=${location.spaces}&fields=files(id,name)`
+      `https://www.googleapis.com/drive/v3/files?q=${encodedQuery}&spaces=${location.spaces}&fields=files(id,name)`
     );
     const payload = await response.json();
     return payload.files?.[0]?.id ?? "";
   };
+
+  const listFiles = async (location, query) => {
+    const encodedQuery = encodeURIComponent(query);
+    const response = await apiFetch(
+      `https://www.googleapis.com/drive/v3/files?q=${encodedQuery}&spaces=${location.spaces}&fields=files(id,name)`
+    );
+    const payload = await response.json();
+    return payload.files ?? [];
+  };
+
+  const listNoteFiles = async (location) =>
+    listFiles(
+      location,
+      `name contains '${noteFilePrefix}' and 'appDataFolder' in parents and trashed=false`
+    );
 
   const fetchUserEmail = async () => {
     const response = await apiFetch(
@@ -270,85 +297,181 @@
     });
   };
 
-  const upload = async (payload, { remoteWorkspaceFileId, remoteWorkspaceParentId }) => {
+  const upsertJsonFile = async ({ fileId, name, parents }, payload) => {
+    if (fileId) {
+      try {
+        const multipart = buildMultipartJsonBody({ mimeType: "application/json" }, payload);
+        await apiFetch(
+          `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=multipart&fields=id`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": multipart.contentType },
+            body: multipart.body
+          }
+        );
+        return fileId;
+      } catch (error) {
+        if (error.status !== 404) {
+          throw error;
+        }
+      }
+    }
+
+    const multipart = buildMultipartJsonBody(
+      {
+        name,
+        parents,
+        mimeType: "application/json"
+      },
+      payload
+    );
+    const createResponse = await apiFetch(
+      "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id",
+      {
+        method: "POST",
+        headers: { "Content-Type": multipart.contentType },
+        body: multipart.body
+      }
+    );
+    const responsePayload = await createResponse.json();
+    return responsePayload.id ?? "";
+  };
+
+  const readJsonFile = async (fileId) => {
+    const response = await apiFetch(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`);
+    return response.json();
+  };
+
+  const upload = async (payload, { remoteSettingsFileId, remoteNoteFileIds = {} }) => {
     try {
       const location = resolveLocation();
       const updatedParentId = location.remoteWorkspaceParentId;
-      let fileId = await findWorkspaceFileId(remoteWorkspaceFileId, location);
+      const settingsQuery = `name='${settingsFileName}' and 'appDataFolder' in parents and trashed=false`;
+      const existingSettingsFileId = await findFileId(remoteSettingsFileId, location, settingsQuery);
+      const nextSettingsFileId = await upsertJsonFile(
+        {
+          fileId: existingSettingsFileId,
+          name: settingsFileName,
+          parents: location.parents
+        },
+        payload.settings
+      );
 
-      if (fileId) {
-        try {
-          const multipart = buildMultipartJsonBody({ mimeType: "application/json" }, payload);
-          await apiFetch(
-            `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=multipart&fields=id`,
-            {
-              method: "PATCH",
-              headers: { "Content-Type": multipart.contentType },
-              body: multipart.body
-            }
-          );
+      const existingNoteFiles = await listNoteFiles(location);
+      const existingNoteFileByName = new Map(existingNoteFiles.map((file) => [file.name, file.id]));
+      const desiredNoteFileNames = new Set();
+      const nextNoteFileIds = {};
 
-          return { remoteWorkspaceFileId: fileId, remoteWorkspaceParentId: updatedParentId };
-        } catch (patchError) {
-          if (patchError.status !== 404) {
-            throw patchError;
+      for (const note of payload.notes.notes) {
+        const fileName = getNoteFileName(note.id);
+        desiredNoteFileNames.add(fileName);
+        const fileId = await upsertJsonFile(
+          {
+            fileId: remoteNoteFileIds[note.id] || existingNoteFileByName.get(fileName) || "",
+            name: fileName,
+            parents: location.parents
+          },
+          {
+            version: 2,
+            updatedAt: payload.updatedAt,
+            note
           }
-
-          // The cached file ID no longer exists — fall through to create a new one.
-          fileId = "";
-        }
+        );
+        nextNoteFileIds[note.id] = fileId;
       }
 
-      const multipart = buildMultipartJsonBody(
-        {
-          name: workspaceFileName,
-          parents: location.parents,
-          mimeType: "application/json"
-        },
-        payload
+      await Promise.all(
+        existingNoteFiles
+          .filter((file) => !desiredNoteFileNames.has(file.name))
+          .map((file) => apiFetch(`https://www.googleapis.com/drive/v3/files/${file.id}`, { method: "DELETE" }))
       );
-      const createResponse = await apiFetch(
-        "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id",
-        {
-          method: "POST",
-          headers: { "Content-Type": multipart.contentType },
-          body: multipart.body
-        }
-      );
-      const responsePayload = await createResponse.json();
-      fileId = responsePayload.id ?? "";
 
-      return { remoteWorkspaceFileId: fileId, remoteWorkspaceParentId: updatedParentId };
+      return {
+        remoteSettingsFileId: nextSettingsFileId,
+        remoteNoteFileIds: nextNoteFileIds,
+        remoteWorkspaceFileId: "",
+        remoteWorkspaceParentId: updatedParentId
+      };
     } catch (error) {
       throw new Error(parseErrorMessage(error));
     }
   };
 
-  const download = async ({ remoteWorkspaceFileId }) => {
+  const download = async ({ remoteSettingsFileId }) => {
     try {
       const location = resolveLocation();
       const updatedParentId = location.remoteWorkspaceParentId;
-      const fileId = await findWorkspaceFileId(remoteWorkspaceFileId, location);
+      const settingsQuery = `name='${settingsFileName}' and 'appDataFolder' in parents and trashed=false`;
+      let settingsFileId = await findFileId(remoteSettingsFileId, location, settingsQuery);
+      const noteFiles = await listNoteFiles(location);
 
-      if (!fileId) {
-        return { data: null, remoteWorkspaceFileId: "", remoteWorkspaceParentId: updatedParentId };
+      if (!settingsFileId && !noteFiles.length) {
+        return {
+          data: null,
+          remoteSettingsFileId: "",
+          remoteNoteFileIds: {},
+          remoteWorkspaceFileId: "",
+          remoteWorkspaceParentId: updatedParentId
+        };
       }
 
-      try {
-        const response = await apiFetch(
-          `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`
-        );
-        const data = await response.json();
+      let settingsPayload = {};
 
-        return { data, remoteWorkspaceFileId: fileId, remoteWorkspaceParentId: updatedParentId };
-      } catch (getError) {
-        if (getError.status !== 404) {
-          throw getError;
+      if (settingsFileId) {
+        try {
+          settingsPayload = await readJsonFile(settingsFileId);
+        } catch (error) {
+          if (error.status !== 404) {
+            throw error;
+          }
+
+          settingsFileId = "";
+        }
+      }
+
+      const notePayloads = await Promise.all(
+        noteFiles.map(async (file) => {
+          const payload = await readJsonFile(file.id);
+          return { file, payload };
+        })
+      );
+
+      const notes = [];
+      const nextNoteFileIds = {};
+      const timestamps = [];
+
+      if (settingsPayload.updatedAt) {
+        timestamps.push(settingsPayload.updatedAt);
+      }
+
+      for (const { file, payload } of notePayloads) {
+        const noteId = getNoteIdFromFileName(file.name) || payload.note?.id || payload.id;
+        const note = payload.note ?? payload;
+
+        if (!noteId || !note) {
+          continue;
         }
 
-        // The cached file ID no longer exists — treat as no file present.
-        return { data: null, remoteWorkspaceFileId: "", remoteWorkspaceParentId: updatedParentId };
+        nextNoteFileIds[noteId] = file.id;
+        notes.push(note);
+        timestamps.push(payload.updatedAt ?? note.updatedAt);
       }
+
+      const latestUpdatedAt = timestamps
+        .filter(Boolean)
+        .sort((left, right) => new Date(right) - new Date(left))[0] ?? null;
+
+      return {
+        data: {
+          ...settingsPayload,
+          updatedAt: latestUpdatedAt,
+          notes
+        },
+        remoteSettingsFileId: settingsFileId,
+        remoteNoteFileIds: nextNoteFileIds,
+        remoteWorkspaceFileId: "",
+        remoteWorkspaceParentId: updatedParentId
+      };
     } catch (error) {
       throw new Error(parseErrorMessage(error));
     }

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
         ></div>
 
         <div class="panel-footer">
-          <p id="save-status">Saved locally just now • Not synced to cloud yet</p>
+          <p id="save-status" class="save-status"></p>
         </div>
       </section>
 

--- a/localdrive.js
+++ b/localdrive.js
@@ -2,14 +2,17 @@
  * Local Drive storage provider for ChurchScribe.
  *
  * Exposes window.LocalDriveProvider, which implements the StorageProvider interface.
- * Uses the File System Access API to read/write a workspace file in a user-chosen
- * local folder. The chosen directory handle is persisted to IndexedDB so the app
- * can restore access across page loads (subject to browser permission state).
+ * Uses the File System Access API to read/write a settings file plus one file per
+ * note in a user-chosen local folder. The chosen directory handle is persisted to
+ * IndexedDB so the app can restore access across page loads (subject to browser
+ * permission state).
  *
  * See gdrive.js for the full StorageProvider interface documentation.
  */
 (() => {
-  const WORKSPACE_FILENAME = "churchscribe-workspace.json";
+  const SETTINGS_FILENAME = "churchscribe-settings.json";
+  const NOTE_FILE_PREFIX = "churchscribe-note-";
+  const NOTE_FILE_SUFFIX = ".json";
   const HANDLE_DB_NAME = "churchscribe-local-drive-db";
   const HANDLE_DB_VERSION = 1;
   const HANDLE_STORE_NAME = "handles";
@@ -131,12 +134,15 @@
     throw new Error("Permission to local folder not available. Click 'Choose Folder' to grant access.");
   };
 
-  const upload = async (payload) => {
-    if (!directoryHandle) {
-      throw new Error("No local folder selected. Choose a folder first.");
-    }
+  const getNoteFileName = (noteId) => `${NOTE_FILE_PREFIX}${noteId}${NOTE_FILE_SUFFIX}`;
 
-    const fileHandle = await directoryHandle.getFileHandle(WORKSPACE_FILENAME, { create: true });
+  const getNoteIdFromFileName = (fileName) =>
+    fileName.startsWith(NOTE_FILE_PREFIX) && fileName.endsWith(NOTE_FILE_SUFFIX)
+      ? fileName.slice(NOTE_FILE_PREFIX.length, -NOTE_FILE_SUFFIX.length)
+      : "";
+
+  const writeJsonFile = async (fileName, payload) => {
+    const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
     const writable = await fileHandle.createWritable();
 
     try {
@@ -146,38 +152,136 @@
       await writable.abort();
       throw error;
     }
+  };
+
+  const readJsonFile = async (fileName) => {
+    const fileHandle = await directoryHandle.getFileHandle(fileName);
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    return JSON.parse(text);
+  };
+
+  const listNoteFiles = async () => {
+    const files = [];
+
+    for await (const entry of directoryHandle.values()) {
+      if (entry.kind === "file" && entry.name.startsWith(NOTE_FILE_PREFIX) && entry.name.endsWith(NOTE_FILE_SUFFIX)) {
+        files.push(entry.name);
+      }
+    }
+
+    return files;
+  };
+
+  const upload = async (payload) => {
+    if (!directoryHandle) {
+      throw new Error("No local folder selected. Choose a folder first.");
+    }
+
+    await writeJsonFile(SETTINGS_FILENAME, payload.settings);
+
+    const existingNoteFiles = await listNoteFiles();
+    const desiredNoteFiles = new Set();
+    const remoteNoteFileIds = {};
+
+    for (const note of payload.notes.notes) {
+      const fileName = getNoteFileName(note.id);
+      desiredNoteFiles.add(fileName);
+      remoteNoteFileIds[note.id] = fileName;
+      await writeJsonFile(fileName, {
+        version: 2,
+        updatedAt: payload.updatedAt,
+        note
+      });
+    }
+
+    await Promise.all(
+      existingNoteFiles
+        .filter((fileName) => !desiredNoteFiles.has(fileName))
+        .map((fileName) => directoryHandle.removeEntry(fileName))
+    );
 
     return {
-      remoteWorkspaceFileId: WORKSPACE_FILENAME,
+      remoteSettingsFileId: SETTINGS_FILENAME,
+      remoteNoteFileIds,
+      remoteWorkspaceFileId: "",
       remoteWorkspaceParentId: directoryHandle.name
     };
   };
 
   const download = async () => {
     if (!directoryHandle) {
-      return { data: null, remoteWorkspaceFileId: "", remoteWorkspaceParentId: "" };
+      return {
+        data: null,
+        remoteSettingsFileId: "",
+        remoteNoteFileIds: {},
+        remoteWorkspaceFileId: "",
+        remoteWorkspaceParentId: ""
+      };
     }
 
     try {
-      const fileHandle = await directoryHandle.getFileHandle(WORKSPACE_FILENAME);
-      const file = await fileHandle.getFile();
-      const text = await file.text();
-      const data = JSON.parse(text);
+      const noteFiles = await listNoteFiles();
+      let settingsPayload = {};
 
-      return {
-        data,
-        remoteWorkspaceFileId: WORKSPACE_FILENAME,
-        remoteWorkspaceParentId: directoryHandle.name
-      };
-    } catch (error) {
-      if (error.name === "NotFoundError") {
+      try {
+        settingsPayload = await readJsonFile(SETTINGS_FILENAME);
+      } catch (error) {
+        if (error.name !== "NotFoundError") {
+          throw error;
+        }
+      }
+
+      if (!Object.keys(settingsPayload).length && !noteFiles.length) {
         return {
           data: null,
+          remoteSettingsFileId: "",
+          remoteNoteFileIds: {},
           remoteWorkspaceFileId: "",
           remoteWorkspaceParentId: directoryHandle.name
         };
       }
 
+      const notes = [];
+      const remoteNoteFileIds = {};
+      const timestamps = [];
+
+      if (settingsPayload.updatedAt) {
+        timestamps.push(settingsPayload.updatedAt);
+      }
+
+      for (const fileName of noteFiles) {
+        const payload = await readJsonFile(fileName);
+        const noteId = getNoteIdFromFileName(fileName) || payload.note?.id || payload.id;
+        const note = payload.note ?? payload;
+
+        if (!noteId || !note) {
+          continue;
+        }
+
+        remoteNoteFileIds[noteId] = fileName;
+        notes.push(note);
+        timestamps.push(payload.updatedAt ?? note.updatedAt);
+      }
+
+      const latestUpdatedAt = timestamps
+        .filter(Boolean)
+        .sort((left, right) => new Date(right) - new Date(left))[0] ?? null;
+
+      const data = {
+        ...settingsPayload,
+        updatedAt: latestUpdatedAt,
+        notes
+      };
+
+      return {
+        data,
+        remoteSettingsFileId: Object.keys(settingsPayload).length ? SETTINGS_FILENAME : "",
+        remoteNoteFileIds,
+        remoteWorkspaceFileId: "",
+        remoteWorkspaceParentId: directoryHandle.name
+      };
+    } catch (error) {
       throw error;
     }
   };

--- a/styles.css
+++ b/styles.css
@@ -611,6 +611,30 @@ h1 {
   font-size: 0.92rem;
 }
 
+.save-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.save-status-sync {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.save-status-sync:hover,
+.save-status-sync:focus-visible {
+  color: var(--muted);
+  opacity: 0.82;
+  outline: none;
+}
+
 .note-editor h2 {
   font-size: 1.55rem;
   margin-bottom: 0.25em;


### PR DESCRIPTION
## Summary
- split cloud sync into a dedicated settings file plus one file per note
- update Google Drive and Local Drive providers to write, read, and prune individual note files
- track settings-only changes separately so cloud sync still notices non-note edits

Closes #5