### PR TITLE
Add a grouped notes browser

### DIFF
--- a/app.js
+++ b/app.js
@@ -3567,6 +3567,13 @@ const closeColorPicker = () => {
   colorPickerTrigger.setAttribute("aria-expanded", "false");
 };
 
+const closeOverflowMenu = () => {
+  overflowMenu.removeAttribute("open");
+  overflowMenu.querySelectorAll("details[open]").forEach((menu) => {
+    menu.removeAttribute("open");
+  });
+};
+
 colorPickerTrigger.addEventListener("click", (e) => {
   e.stopPropagation();
   if (colorPickerDropdown.hidden) {
@@ -3582,7 +3589,7 @@ document.addEventListener("click", (e) => {
   }
 
   if (!overflowMenu.contains(e.target)) {
-    overflowMenu.removeAttribute("open");
+    closeOverflowMenu();
   }
 });
 
@@ -3601,12 +3608,11 @@ newNoteActions.addEventListener("click", (event) => {
   }
 
   createNote(trigger.dataset.newNoteType);
-  trigger.closest(".inline-action-menu")?.removeAttribute("open");
-  overflowMenu.removeAttribute("open");
+  closeOverflowMenu();
 });
 deleteNoteButton.addEventListener("click", () => {
   deleteNoteById(workspace.activeNoteId);
-  overflowMenu.removeAttribute("open");
+  closeOverflowMenu();
 });
 noteDetailsButton.addEventListener("click", () => {
   renderNoteMetadataFields();
@@ -3619,7 +3625,7 @@ manageNotesButton.addEventListener("click", () => {
 
 settingsButton.addEventListener("click", () => {
   renderSettings();
-  overflowMenu.removeAttribute("open");
+  closeOverflowMenu();
   openDialog(settingsDialog);
 });
 

--- a/app.js
+++ b/app.js
@@ -12,17 +12,13 @@ const translationLibrary = {
 const noteEditor = document.querySelector("#note-editor");
 const saveStatus = document.querySelector("#save-status");
 const toolbarButtons = document.querySelectorAll(".tool-button");
-const newNoteButton = document.querySelector("#new-note-button");
+const newNoteActions = document.querySelector("#new-note-actions");
 const deleteNoteButton = document.querySelector("#delete-note-button");
 const manageNotesButton = document.querySelector("#manage-notes-button");
 const settingsButton = document.querySelector("#settings-button");
 const noteDetailsButton = document.querySelector("#note-details-button");
 const activeNoteTitle = document.querySelector("#active-note-title");
 const activeNoteMeta = document.querySelector("#active-note-meta");
-const noteTypeSelect = document.querySelector("#note-type-select");
-const newNoteTypeSelect = document.querySelector("#new-note-type-select");
-const newNoteTypeField = document.querySelector("#new-note-type-field");
-const activeNoteTypeField = document.querySelector("#active-note-type-field");
 const metadataSummary = document.querySelector("#metadata-summary");
 const noteMetaFields = document.querySelector("#note-meta-fields");
 const translationSelect = document.querySelector("#translation-select");
@@ -2445,27 +2441,44 @@ const getNotePreviewText = (note) => note.content
   .trim();
 
 const renderNoteTypeOptions = () => {
-  const activeNote = getActiveNote();
   const showTypeChoices = workspace.noteTypes.length > 1;
-  noteTypeSelect.innerHTML = "";
-  newNoteTypeSelect.innerHTML = "";
+  newNoteActions.innerHTML = "";
+
+  if (!workspace.noteTypes.length) {
+    return;
+  }
+
+  if (!showTypeChoices) {
+    const singleTypeButton = document.createElement("button");
+    singleTypeButton.type = "button";
+    singleTypeButton.className = "ghost-button overflow-action";
+    singleTypeButton.dataset.newNoteType = workspace.noteTypes[0].id;
+    singleTypeButton.textContent = "New note";
+    newNoteActions.append(singleTypeButton);
+    return;
+  }
+
+  const menu = document.createElement("details");
+  menu.className = "inline-action-menu";
+
+  const summary = document.createElement("summary");
+  summary.className = "ghost-button overflow-action";
+  summary.textContent = "New note ▾";
+
+  const panel = document.createElement("div");
+  panel.className = "overflow-menu-panel inline-action-panel";
 
   workspace.noteTypes.forEach((type) => {
-    const activeOption = document.createElement("option");
-    activeOption.value = type.id;
-    activeOption.textContent = type.name;
-    noteTypeSelect.append(activeOption);
-
-    const newNoteOption = document.createElement("option");
-    newNoteOption.value = type.id;
-    newNoteOption.textContent = type.name;
-    newNoteTypeSelect.append(newNoteOption);
+    const typeButton = document.createElement("button");
+    typeButton.type = "button";
+    typeButton.className = "ghost-button overflow-action";
+    typeButton.dataset.newNoteType = type.id;
+    typeButton.textContent = type.name;
+    panel.append(typeButton);
   });
 
-  noteTypeSelect.value = activeNote.typeId;
-  newNoteTypeSelect.value = workspace.selectedNewNoteTypeId;
-  newNoteTypeField.classList.toggle("is-hidden", !showTypeChoices);
-  activeNoteTypeField.classList.toggle("is-hidden", !showTypeChoices);
+  menu.append(summary, panel);
+  newNoteActions.append(menu);
 };
 
 const renderMetadataSummary = () => {
@@ -2509,6 +2522,29 @@ const renderNoteMetadataFields = () => {
   const activeNote = getActiveNote();
   const type = getNoteTypeById(activeNote.typeId);
   noteMetaFields.innerHTML = "";
+
+  if (workspace.noteTypes.length > 1) {
+    const typeField = document.createElement("label");
+    typeField.className = "field";
+
+    const typeLabel = document.createElement("span");
+    typeLabel.textContent = "Note type";
+
+    const typeSelect = document.createElement("select");
+    typeSelect.name = "active-note-type";
+    typeSelect.dataset.noteTypeChange = activeNote.id;
+
+    workspace.noteTypes.forEach((noteType) => {
+      const option = document.createElement("option");
+      option.value = noteType.id;
+      option.textContent = noteType.name;
+      typeSelect.append(option);
+    });
+
+    typeSelect.value = activeNote.typeId;
+    typeField.append(typeLabel, typeSelect);
+    noteMetaFields.append(typeField);
+  }
 
   type.fields.forEach((field) => {
     const label = document.createElement("label");
@@ -2663,28 +2699,6 @@ const renderNoteManager = () => {
 
   detailHeader.append(detailLabel, detailTitle, detailMeta);
 
-  const detailControls = document.createElement("div");
-  detailControls.className = "note-browser-detail-controls";
-
-  const typePicker = document.createElement("label");
-  typePicker.className = "field compact-field";
-
-  const typePickerLabel = document.createElement("span");
-  typePickerLabel.textContent = "Type";
-
-  const select = document.createElement("select");
-  select.dataset.noteMove = selectedNote.id;
-
-  workspace.noteTypes.forEach((type) => {
-    const option = document.createElement("option");
-    option.value = type.id;
-    option.textContent = type.name;
-    select.append(option);
-  });
-
-  select.value = selectedNote.typeId;
-  typePicker.append(typePickerLabel, select);
-
   const actions = document.createElement("div");
   actions.className = "note-browser-detail-actions";
 
@@ -2710,7 +2724,6 @@ const renderNoteManager = () => {
   deleteButton.textContent = "Delete";
 
   actions.append(openButton, duplicateButton, deleteButton);
-  detailControls.append(typePicker, actions);
 
   const metadataBlock = document.createElement("div");
   metadataBlock.className = "note-browser-detail-block";
@@ -2765,7 +2778,7 @@ const renderNoteManager = () => {
   preview.textContent = previewText || "This note is still empty.";
 
   previewBlock.append(previewTitle, preview);
-  noteBrowserDetails.append(detailHeader, detailControls, metadataBlock, previewBlock);
+  noteBrowserDetails.append(detailHeader, actions, metadataBlock, previewBlock);
 };
 
 const renderProviderSettings = () => {
@@ -3157,13 +3170,14 @@ const saveActiveNote = () => {
   refreshSaveStatus();
 };
 
-const setSelectedNewNoteType = (typeId) => {
-  workspace.selectedNewNoteTypeId = typeId;
-  persistWorkspace();
-};
+const createNote = (typeId = workspace.selectedNewNoteTypeId) => {
+  const type = getNoteTypeById(typeId) ?? workspace.noteTypes[0];
 
-const createNote = () => {
-  const type = getNoteTypeById(workspace.selectedNewNoteTypeId);
+  if (!type) {
+    return;
+  }
+
+  workspace.selectedNewNoteTypeId = type.id;
   const note = createEmptyNote(type.id, buildMetadataForType(type));
   workspace.notes.unshift(note);
   workspace.activeNoteId = note.id;
@@ -3575,8 +3589,15 @@ document.addEventListener("keydown", (e) => {
   }
 });
 
-newNoteButton.addEventListener("click", () => {
-  createNote();
+newNoteActions.addEventListener("click", (event) => {
+  const trigger = event.target.closest("[data-new-note-type]");
+
+  if (!trigger) {
+    return;
+  }
+
+  createNote(trigger.dataset.newNoteType);
+  trigger.closest(".inline-action-menu")?.removeAttribute("open");
   overflowMenu.removeAttribute("open");
 });
 deleteNoteButton.addEventListener("click", () => {
@@ -3596,14 +3617,6 @@ settingsButton.addEventListener("click", () => {
   renderSettings();
   overflowMenu.removeAttribute("open");
   openDialog(settingsDialog);
-});
-
-noteTypeSelect.addEventListener("change", () => {
-  changeNoteType(workspace.activeNoteId, noteTypeSelect.value);
-});
-
-newNoteTypeSelect.addEventListener("change", () => {
-  setSelectedNewNoteType(newNoteTypeSelect.value);
 });
 
 cardTitleFieldSelect.addEventListener("change", updateSelectedTypeCardFields);
@@ -3638,6 +3651,16 @@ noteMetaFields.addEventListener("input", () => {
   persistWorkspace();
   refreshNoteSurfaces();
   refreshSaveStatus();
+});
+
+noteMetaFields.addEventListener("change", (event) => {
+  const typeSelect = event.target.closest("[data-note-type-change]");
+
+  if (!typeSelect) {
+    return;
+  }
+
+  changeNoteType(typeSelect.dataset.noteTypeChange, typeSelect.value);
 });
 
 noteEditor.addEventListener("input", (event) => {
@@ -3772,16 +3795,6 @@ noteBrowserDetails.addEventListener("click", (event) => {
   if (noteAction === "delete") {
     deleteNoteById(noteId);
   }
-});
-
-noteBrowserDetails.addEventListener("change", (event) => {
-  const moveSelect = event.target.closest("[data-note-move]");
-
-  if (!moveSelect) {
-    return;
-  }
-
-  changeNoteType(moveSelect.dataset.noteMove, moveSelect.value);
 });
 
 typeSelect.addEventListener("change", () => {

--- a/app.js
+++ b/app.js
@@ -12,12 +12,9 @@ const translationLibrary = {
 const noteEditor = document.querySelector("#note-editor");
 const saveStatus = document.querySelector("#save-status");
 const toolbarButtons = document.querySelectorAll(".tool-button");
-const newNoteDirectButton = document.querySelector("#new-note-direct-button");
 const newNoteButton = document.querySelector("#new-note-button");
-const duplicateNoteButton = document.querySelector("#duplicate-note-button");
 const deleteNoteButton = document.querySelector("#delete-note-button");
 const manageNotesButton = document.querySelector("#manage-notes-button");
-const browseNotesButton = document.querySelector("#browse-notes-button");
 const settingsButton = document.querySelector("#settings-button");
 const noteDetailsButton = document.querySelector("#note-details-button");
 const activeNoteTitle = document.querySelector("#active-note-title");
@@ -65,7 +62,6 @@ const googleSyncNowButton = document.querySelector("#google-sync-now-button");
 const addTypeButton = document.querySelector("#add-type-button");
 const addMetadataFieldButton = document.querySelector("#add-metadata-field-button");
 const deleteTypeButton = document.querySelector("#delete-type-button");
-const newNoteMenu = document.querySelector("#new-note-menu");
 const overflowMenu = document.querySelector(".overflow-menu");
 const syncConflictDialog = document.querySelector("#sync-conflict-dialog");
 const conflictLocalTime = document.querySelector("#conflict-local-time");
@@ -2468,8 +2464,6 @@ const renderNoteTypeOptions = () => {
 
   noteTypeSelect.value = activeNote.typeId;
   newNoteTypeSelect.value = workspace.selectedNewNoteTypeId;
-  newNoteDirectButton.classList.toggle("is-hidden", showTypeChoices);
-  newNoteMenu.classList.toggle("is-hidden", !showTypeChoices);
   newNoteTypeField.classList.toggle("is-hidden", !showTypeChoices);
   activeNoteTypeField.classList.toggle("is-hidden", !showTypeChoices);
 };
@@ -2694,12 +2688,12 @@ const renderNoteManager = () => {
   const actions = document.createElement("div");
   actions.className = "note-browser-detail-actions";
 
-  const openButton = document.createElement("button");
-  openButton.type = "button";
-  openButton.className = "ghost-button";
-  openButton.dataset.noteAction = "open";
-  openButton.dataset.noteId = selectedNote.id;
-  openButton.textContent = "Open note";
+        const openButton = document.createElement("button");
+        openButton.type = "button";
+        openButton.className = "ghost-button primary-button";
+        openButton.dataset.noteAction = "open";
+        openButton.dataset.noteId = selectedNote.id;
+        openButton.textContent = "Open note";
 
   const duplicateButton = document.createElement("button");
   duplicateButton.type = "button";
@@ -3581,13 +3575,8 @@ document.addEventListener("keydown", (e) => {
   }
 });
 
-newNoteDirectButton.addEventListener("click", createNote);
 newNoteButton.addEventListener("click", () => {
   createNote();
-  newNoteMenu.removeAttribute("open");
-});
-duplicateNoteButton.addEventListener("click", () => {
-  duplicateNote();
   overflowMenu.removeAttribute("open");
 });
 deleteNoteButton.addEventListener("click", () => {
@@ -3602,8 +3591,6 @@ noteDetailsButton.addEventListener("click", () => {
 manageNotesButton.addEventListener("click", () => {
   openNotesBrowser();
 });
-
-browseNotesButton.addEventListener("click", openNotesBrowser);
 
 settingsButton.addEventListener("click", () => {
   renderSettings();
@@ -3753,6 +3740,17 @@ noteManagerList.addEventListener("click", (event) => {
     noteBrowserSelectedNoteId = selectionButton.dataset.noteSelect;
     renderNoteManager();
   }
+});
+
+noteManagerList.addEventListener("dblclick", (event) => {
+  const selectionButton = event.target.closest("[data-note-select]");
+
+  if (!selectionButton) {
+    return;
+  }
+
+  switchNote(selectionButton.dataset.noteSelect);
+  noteManagerDialog.close();
 });
 
 noteBrowserDetails.addEventListener("click", (event) => {

--- a/app.js
+++ b/app.js
@@ -2525,7 +2525,7 @@ const renderNoteMetadataFields = () => {
 
   if (workspace.noteTypes.length > 1) {
     const typeField = document.createElement("label");
-    typeField.className = "field";
+    typeField.className = "field note-meta-primary-field";
 
     const typeLabel = document.createElement("span");
     typeLabel.textContent = "Note type";
@@ -3579,6 +3579,10 @@ colorPickerTrigger.addEventListener("click", (e) => {
 document.addEventListener("click", (e) => {
   if (!colorPickerWrapper.contains(e.target)) {
     closeColorPicker();
+  }
+
+  if (!overflowMenu.contains(e.target)) {
+    overflowMenu.removeAttribute("open");
   }
 });
 

--- a/app.js
+++ b/app.js
@@ -3737,20 +3737,15 @@ noteManagerList.addEventListener("click", (event) => {
   const selectionButton = event.target.closest("[data-note-select]");
 
   if (selectionButton) {
+    if (event.detail > 1) {
+      switchNote(selectionButton.dataset.noteSelect);
+      noteManagerDialog.close();
+      return;
+    }
+
     noteBrowserSelectedNoteId = selectionButton.dataset.noteSelect;
     renderNoteManager();
   }
-});
-
-noteManagerList.addEventListener("dblclick", (event) => {
-  const selectionButton = event.target.closest("[data-note-select]");
-
-  if (!selectionButton) {
-    return;
-  }
-
-  switchNote(selectionButton.dataset.noteSelect);
-  noteManagerDialog.close();
 });
 
 noteBrowserDetails.addEventListener("click", (event) => {

--- a/app.js
+++ b/app.js
@@ -17,9 +17,11 @@ const newNoteButton = document.querySelector("#new-note-button");
 const duplicateNoteButton = document.querySelector("#duplicate-note-button");
 const deleteNoteButton = document.querySelector("#delete-note-button");
 const manageNotesButton = document.querySelector("#manage-notes-button");
+const browseNotesButton = document.querySelector("#browse-notes-button");
 const settingsButton = document.querySelector("#settings-button");
 const noteDetailsButton = document.querySelector("#note-details-button");
-const noteList = document.querySelector("#note-list");
+const activeNoteTitle = document.querySelector("#active-note-title");
+const activeNoteMeta = document.querySelector("#active-note-meta");
 const noteTypeSelect = document.querySelector("#note-type-select");
 const newNoteTypeSelect = document.querySelector("#new-note-type-select");
 const newNoteTypeField = document.querySelector("#new-note-type-field");
@@ -35,6 +37,9 @@ const verseTranslation = document.querySelector("#verse-translation");
 const paneGrid = document.querySelector(".pane-grid");
 const noteManagerDialog = document.querySelector("#note-manager-dialog");
 const noteManagerList = document.querySelector("#note-manager-list");
+const noteBrowserFilterInput = document.querySelector("#note-browser-filter");
+const noteBrowserTypeFilterSelect = document.querySelector("#note-browser-type-filter");
+const noteBrowserSortSelect = document.querySelector("#note-browser-sort");
 const noteDetailsDialog = document.querySelector("#note-details-dialog");
 const settingsDialog = document.querySelector("#settings-dialog");
 const settingsTabNav = document.querySelector("#settings-tab-nav");
@@ -157,6 +162,9 @@ let activeSettingsTabId = "ui-settings";
 let currentColorThemeId = "default";
 let currentThemeMode = "system";
 let currentPaneSplit = 0.6;
+let noteBrowserFilter = "";
+let noteBrowserTypeFilter = "all";
+let noteBrowserSort = "updated-desc";
 let dbPromise;
 let pendingAutoSyncTimer = null;
 let syncInFlightPromise = null;
@@ -2372,6 +2380,49 @@ const getNoteDisplayMeta = (note) => {
   return secondaryValue || "";
 };
 
+const getNoteSearchableText = (note) => {
+  const metadataText = Object.values(note.metadata)
+    .filter((value) => typeof value === "string" && value.trim())
+    .join(" ");
+  const contentText = note.content.replace(/<[^>]+>/g, " ");
+  return [getNoteDisplayTitle(note), getNoteDisplayMeta(note), metadataText, contentText].join(" ").toLowerCase();
+};
+
+const sortNotes = (notes) => {
+  const sortedNotes = notes.slice();
+
+  if (noteBrowserSort === "created-desc") {
+    return sortedNotes.sort((left, right) => new Date(right.createdAt) - new Date(left.createdAt));
+  }
+
+  if (noteBrowserSort === "title-asc") {
+    return sortedNotes.sort((left, right) => getNoteDisplayTitle(left).localeCompare(getNoteDisplayTitle(right)));
+  }
+
+  return sortedNotes.sort((left, right) => new Date(right.updatedAt) - new Date(left.updatedAt));
+};
+
+const getFilteredNotes = () => {
+  const query = noteBrowserFilter.trim().toLowerCase();
+  const activeTypeFilter = workspace.noteTypes.some((type) => type.id === noteBrowserTypeFilter)
+    ? noteBrowserTypeFilter
+    : "all";
+
+  return sortNotes(
+    workspace.notes.filter((note) => {
+      if (activeTypeFilter !== "all" && note.typeId !== activeTypeFilter) {
+        return false;
+      }
+
+      if (!query) {
+        return true;
+      }
+
+      return getNoteSearchableText(note).includes(query);
+    })
+  );
+};
+
 const renderNoteTypeOptions = () => {
   const activeNote = getActiveNote();
   const showTypeChoices = workspace.noteTypes.length > 1;
@@ -2459,59 +2510,19 @@ const renderNoteMetadataFields = () => {
   });
 };
 
-const renderNoteList = () => {
-  noteList.innerHTML = "";
+const renderActiveNoteSummary = () => {
+  const activeNote = getActiveNote();
+  const type = getNoteTypeById(activeNote.typeId);
+  const metaBits = [type.name];
+  const secondaryMeta = getNoteDisplayMeta(activeNote);
 
-  workspace.noteTypes.forEach((type) => {
-    const notesForType = workspace.notes.filter((note) => note.typeId === type.id);
+  if (secondaryMeta) {
+    metaBits.push(secondaryMeta);
+  }
 
-    if (!notesForType.length) {
-      return;
-    }
-
-    const group = document.createElement("section");
-    group.className = "note-group";
-
-    const heading = document.createElement("h3");
-    heading.className = "note-group-heading";
-    heading.textContent = type.name;
-
-    group.append(heading);
-
-    notesForType
-      .sort((left, right) => new Date(right.updatedAt) - new Date(left.updatedAt))
-      .forEach((note) => {
-        const button = document.createElement("button");
-        button.type = "button";
-        button.className = `note-card${note.id === workspace.activeNoteId ? " is-active" : ""}`;
-        button.setAttribute("role", "option");
-        button.setAttribute("aria-selected", String(note.id === workspace.activeNoteId));
-        button.dataset.noteId = note.id;
-
-        const title = document.createElement("span");
-        title.className = "note-card-title";
-        title.textContent = getNoteDisplayTitle(note);
-
-        const meta = document.createElement("span");
-        meta.className = "note-card-meta";
-        meta.textContent = getNoteDisplayMeta(note);
-
-        const updated = document.createElement("span");
-        updated.className = "note-card-date";
-        updated.textContent = formatNoteDate(note.updatedAt);
-
-        button.append(title);
-
-        if (meta.textContent) {
-          button.append(meta);
-        }
-
-        button.append(updated);
-        group.append(button);
-      });
-
-    noteList.append(group);
-  });
+  metaBits.push(`Updated ${formatNoteDate(activeNote.updatedAt)}`);
+  activeNoteTitle.textContent = getNoteDisplayTitle(activeNote);
+  activeNoteMeta.textContent = metaBits.join(" • ");
 };
 
 const renderActiveNote = () => {
@@ -2523,83 +2534,135 @@ const renderActiveNote = () => {
 
   workspace.activeNoteId = activeNote.id;
   renderNoteTypeOptions();
+  renderActiveNoteSummary();
   renderMetadataSummary();
   renderNoteMetadataFields();
   noteEditor.innerHTML = activeNote.content;
   linkifyScriptureReferences();
   linkifyUrls();
-  renderNoteList();
 };
 
 const renderNoteManager = () => {
+  const filteredNotes = getFilteredNotes();
   noteManagerList.innerHTML = "";
 
-  workspace.notes
-    .slice()
-    .sort((left, right) => new Date(right.updatedAt) - new Date(left.updatedAt))
-    .forEach((note) => {
-      const row = document.createElement("div");
-      row.className = "note-manager-row";
-      row.dataset.noteId = note.id;
+  noteBrowserTypeFilterSelect.innerHTML = "";
+  const allOption = document.createElement("option");
+  allOption.value = "all";
+  allOption.textContent = "All note types";
+  noteBrowserTypeFilterSelect.append(allOption);
+  workspace.noteTypes.forEach((type) => {
+    const option = document.createElement("option");
+    option.value = type.id;
+    option.textContent = type.name;
+    noteBrowserTypeFilterSelect.append(option);
+  });
+  noteBrowserFilterInput.value = noteBrowserFilter;
+  noteBrowserTypeFilterSelect.value = workspace.noteTypes.some((type) => type.id === noteBrowserTypeFilter)
+    ? noteBrowserTypeFilter
+    : "all";
+  noteBrowserSortSelect.value = noteBrowserSort;
 
-      const summary = document.createElement("div");
-      summary.className = "note-manager-summary";
+  if (!filteredNotes.length) {
+    const emptyState = document.createElement("p");
+    emptyState.className = "note-browser-empty";
+    emptyState.textContent = noteBrowserFilter || noteBrowserTypeFilter !== "all"
+      ? "No notes match the current filter."
+      : "No notes available.";
+    noteManagerList.append(emptyState);
+    return;
+  }
 
-      const title = document.createElement("span");
-      title.className = "note-manager-title";
-      title.textContent = getNoteDisplayTitle(note);
+  workspace.noteTypes
+    .map((type) => ({
+      type,
+      notes: filteredNotes.filter((note) => note.typeId === type.id)
+    }))
+    .filter((entry) => entry.notes.length)
+    .forEach(({ type, notes }) => {
+      const group = document.createElement("section");
+      group.className = "note-browser-group";
 
-      const meta = document.createElement("span");
-      meta.className = "note-manager-meta";
-      const cardMeta = getNoteDisplayMeta(note);
-      meta.textContent = cardMeta
-        ? `${getNoteTypeById(note.typeId).name} • ${cardMeta} • Updated ${formatNoteDate(note.updatedAt)}`
-        : `${getNoteTypeById(note.typeId).name} • Updated ${formatNoteDate(note.updatedAt)}`;
+      const groupHeader = document.createElement("div");
+      groupHeader.className = "note-browser-group-header";
 
-      summary.append(title, meta);
+      const heading = document.createElement("h3");
+      heading.className = "note-browser-group-title";
+      heading.textContent = type.name;
 
-      const typePicker = document.createElement("label");
-      typePicker.className = "field";
+      const count = document.createElement("span");
+      count.className = "note-browser-group-count";
+      count.textContent = `${notes.length} note${notes.length === 1 ? "" : "s"}`;
 
-      const typePickerLabel = document.createElement("span");
-      typePickerLabel.textContent = "Type";
+      groupHeader.append(heading, count);
+      group.append(groupHeader);
 
-      const select = document.createElement("select");
-      select.dataset.noteMove = note.id;
+      notes.forEach((note) => {
+        const row = document.createElement("div");
+        row.className = `note-manager-row${note.id === workspace.activeNoteId ? " is-active" : ""}`;
+        row.dataset.noteId = note.id;
 
-      workspace.noteTypes.forEach((type) => {
-        const option = document.createElement("option");
-        option.value = type.id;
-        option.textContent = type.name;
-        select.append(option);
+        const summary = document.createElement("div");
+        summary.className = "note-manager-summary";
+
+        const title = document.createElement("span");
+        title.className = "note-manager-title";
+        title.textContent = getNoteDisplayTitle(note);
+
+        const meta = document.createElement("span");
+        meta.className = "note-manager-meta";
+        const cardMeta = getNoteDisplayMeta(note);
+        meta.textContent = cardMeta
+          ? `${cardMeta} • Updated ${formatNoteDate(note.updatedAt)}`
+          : `Updated ${formatNoteDate(note.updatedAt)}`;
+
+        summary.append(title, meta);
+
+        const typePicker = document.createElement("label");
+        typePicker.className = "field";
+
+        const typePickerLabel = document.createElement("span");
+        typePickerLabel.textContent = "Type";
+
+        const select = document.createElement("select");
+        select.dataset.noteMove = note.id;
+
+        workspace.noteTypes.forEach((type) => {
+          const option = document.createElement("option");
+          option.value = type.id;
+          option.textContent = type.name;
+          select.append(option);
+        });
+
+        select.value = note.typeId;
+        typePicker.append(typePickerLabel, select);
+
+        const openButton = document.createElement("button");
+        openButton.type = "button";
+        openButton.className = "ghost-button";
+        openButton.dataset.noteAction = "open";
+        openButton.dataset.noteId = note.id;
+        openButton.textContent = "Open";
+
+        const duplicateButton = document.createElement("button");
+        duplicateButton.type = "button";
+        duplicateButton.className = "ghost-button";
+        duplicateButton.dataset.noteAction = "duplicate";
+        duplicateButton.dataset.noteId = note.id;
+        duplicateButton.textContent = "Copy";
+
+        const deleteButton = document.createElement("button");
+        deleteButton.type = "button";
+        deleteButton.className = "ghost-button";
+        deleteButton.dataset.noteAction = "delete";
+        deleteButton.dataset.noteId = note.id;
+        deleteButton.textContent = "Delete";
+
+        row.append(summary, typePicker, openButton, duplicateButton, deleteButton);
+        group.append(row);
       });
 
-      select.value = note.typeId;
-      typePicker.append(typePickerLabel, select);
-
-      const openButton = document.createElement("button");
-      openButton.type = "button";
-      openButton.className = "ghost-button";
-      openButton.dataset.noteAction = "open";
-      openButton.dataset.noteId = note.id;
-      openButton.textContent = "Open";
-
-      const duplicateButton = document.createElement("button");
-      duplicateButton.type = "button";
-      duplicateButton.className = "ghost-button";
-      duplicateButton.dataset.noteAction = "duplicate";
-      duplicateButton.dataset.noteId = note.id;
-      duplicateButton.textContent = "Copy";
-
-      const deleteButton = document.createElement("button");
-      deleteButton.type = "button";
-      deleteButton.className = "ghost-button";
-      deleteButton.dataset.noteAction = "delete";
-      deleteButton.dataset.noteId = note.id;
-      deleteButton.textContent = "Delete";
-
-      row.append(summary, typePicker, openButton, duplicateButton, deleteButton);
-      noteManagerList.append(row);
+      noteManagerList.append(group);
     });
 };
 
@@ -2957,13 +3020,21 @@ const touchNote = (note) => {
 };
 
 const refreshNoteSurfaces = () => {
-  renderNoteList();
+  renderActiveNoteSummary();
   renderNoteTypeOptions();
   renderMetadataSummary();
 
   if (noteManagerDialog.open) {
     renderNoteManager();
   }
+};
+
+const openNotesBrowser = () => {
+  renderNoteManager();
+  overflowMenu.removeAttribute("open");
+  openDialog(noteManagerDialog);
+  noteBrowserFilterInput.focus();
+  noteBrowserFilterInput.select();
 };
 
 const saveActiveNote = () => {
@@ -3420,10 +3491,10 @@ noteDetailsButton.addEventListener("click", () => {
 });
 
 manageNotesButton.addEventListener("click", () => {
-  renderNoteManager();
-  overflowMenu.removeAttribute("open");
-  openDialog(noteManagerDialog);
+  openNotesBrowser();
 });
+
+browseNotesButton.addEventListener("click", openNotesBrowser);
 
 settingsButton.addEventListener("click", () => {
   renderSettings();
@@ -3442,12 +3513,19 @@ newNoteTypeSelect.addEventListener("change", () => {
 cardTitleFieldSelect.addEventListener("change", updateSelectedTypeCardFields);
 cardSubtitleFieldSelect.addEventListener("change", updateSelectedTypeCardFields);
 
-noteList.addEventListener("click", (event) => {
-  const noteButton = event.target.closest("[data-note-id]");
+noteBrowserFilterInput.addEventListener("input", () => {
+  noteBrowserFilter = noteBrowserFilterInput.value;
+  renderNoteManager();
+});
 
-  if (noteButton) {
-    switchNote(noteButton.dataset.noteId);
-  }
+noteBrowserTypeFilterSelect.addEventListener("change", () => {
+  noteBrowserTypeFilter = noteBrowserTypeFilterSelect.value;
+  renderNoteManager();
+});
+
+noteBrowserSortSelect.addEventListener("change", () => {
+  noteBrowserSort = noteBrowserSortSelect.value;
+  renderNoteManager();
 });
 
 noteMetaFields.addEventListener("input", () => {
@@ -3563,6 +3641,14 @@ noteManagerList.addEventListener("click", (event) => {
   const actionButton = event.target.closest("[data-note-action]");
 
   if (!actionButton) {
+    const row = event.target.closest(".note-manager-row");
+    const clickedInteractive = event.target.closest("button, select, input, label");
+
+    if (row && !clickedInteractive) {
+      switchNote(row.dataset.noteId);
+      noteManagerDialog.close();
+    }
+
     return;
   }
 

--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const verseTranslation = document.querySelector("#verse-translation");
 const paneGrid = document.querySelector(".pane-grid");
 const noteManagerDialog = document.querySelector("#note-manager-dialog");
 const noteManagerList = document.querySelector("#note-manager-list");
+const noteBrowserDetails = document.querySelector("#note-browser-details");
 const noteBrowserFilterInput = document.querySelector("#note-browser-filter");
 const noteBrowserTypeFilterSelect = document.querySelector("#note-browser-type-filter");
 const noteBrowserSortSelect = document.querySelector("#note-browser-sort");
@@ -165,6 +166,7 @@ let currentPaneSplit = 0.6;
 let noteBrowserFilter = "";
 let noteBrowserTypeFilter = "all";
 let noteBrowserSort = "updated-desc";
+let noteBrowserSelectedNoteId = null;
 let dbPromise;
 let pendingAutoSyncTimer = null;
 let syncInFlightPromise = null;
@@ -2423,6 +2425,29 @@ const getFilteredNotes = () => {
   );
 };
 
+const getSelectedBrowserNote = (filteredNotes) => {
+  const selected = filteredNotes.find((note) => note.id === noteBrowserSelectedNoteId);
+
+  if (selected) {
+    return selected;
+  }
+
+  const active = filteredNotes.find((note) => note.id === workspace.activeNoteId);
+
+  if (active) {
+    noteBrowserSelectedNoteId = active.id;
+    return active;
+  }
+
+  noteBrowserSelectedNoteId = filteredNotes[0]?.id ?? null;
+  return filteredNotes[0] ?? null;
+};
+
+const getNotePreviewText = (note) => note.content
+  .replace(/<[^>]+>/g, " ")
+  .replace(/\s+/g, " ")
+  .trim();
+
 const renderNoteTypeOptions = () => {
   const activeNote = getActiveNote();
   const showTypeChoices = workspace.noteTypes.length > 1;
@@ -2545,6 +2570,7 @@ const renderActiveNote = () => {
 const renderNoteManager = () => {
   const filteredNotes = getFilteredNotes();
   noteManagerList.innerHTML = "";
+  noteBrowserDetails.innerHTML = "";
 
   noteBrowserTypeFilterSelect.innerHTML = "";
   const allOption = document.createElement("option");
@@ -2570,8 +2596,11 @@ const renderNoteManager = () => {
       ? "No notes match the current filter."
       : "No notes available.";
     noteManagerList.append(emptyState);
+    noteBrowserSelectedNoteId = null;
     return;
   }
+
+  const selectedNote = getSelectedBrowserNote(filteredNotes);
 
   workspace.noteTypes
     .map((type) => ({
@@ -2598,72 +2627,151 @@ const renderNoteManager = () => {
       group.append(groupHeader);
 
       notes.forEach((note) => {
-        const row = document.createElement("div");
-        row.className = `note-manager-row${note.id === workspace.activeNoteId ? " is-active" : ""}`;
-        row.dataset.noteId = note.id;
-
-        const summary = document.createElement("div");
-        summary.className = "note-manager-summary";
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = `note-browser-list-item${note.id === noteBrowserSelectedNoteId ? " is-selected" : ""}`;
+        row.dataset.noteSelect = note.id;
 
         const title = document.createElement("span");
-        title.className = "note-manager-title";
+        title.className = "note-browser-list-title";
         title.textContent = getNoteDisplayTitle(note);
 
         const meta = document.createElement("span");
-        meta.className = "note-manager-meta";
+        meta.className = "note-browser-list-meta";
         const cardMeta = getNoteDisplayMeta(note);
         meta.textContent = cardMeta
-          ? `${cardMeta} • Updated ${formatNoteDate(note.updatedAt)}`
-          : `Updated ${formatNoteDate(note.updatedAt)}`;
+          ? `${cardMeta} • ${formatNoteDate(note.updatedAt)}`
+          : formatNoteDate(note.updatedAt);
 
-        summary.append(title, meta);
-
-        const typePicker = document.createElement("label");
-        typePicker.className = "field";
-
-        const typePickerLabel = document.createElement("span");
-        typePickerLabel.textContent = "Type";
-
-        const select = document.createElement("select");
-        select.dataset.noteMove = note.id;
-
-        workspace.noteTypes.forEach((type) => {
-          const option = document.createElement("option");
-          option.value = type.id;
-          option.textContent = type.name;
-          select.append(option);
-        });
-
-        select.value = note.typeId;
-        typePicker.append(typePickerLabel, select);
-
-        const openButton = document.createElement("button");
-        openButton.type = "button";
-        openButton.className = "ghost-button";
-        openButton.dataset.noteAction = "open";
-        openButton.dataset.noteId = note.id;
-        openButton.textContent = "Open";
-
-        const duplicateButton = document.createElement("button");
-        duplicateButton.type = "button";
-        duplicateButton.className = "ghost-button";
-        duplicateButton.dataset.noteAction = "duplicate";
-        duplicateButton.dataset.noteId = note.id;
-        duplicateButton.textContent = "Copy";
-
-        const deleteButton = document.createElement("button");
-        deleteButton.type = "button";
-        deleteButton.className = "ghost-button";
-        deleteButton.dataset.noteAction = "delete";
-        deleteButton.dataset.noteId = note.id;
-        deleteButton.textContent = "Delete";
-
-        row.append(summary, typePicker, openButton, duplicateButton, deleteButton);
+        row.append(title, meta);
         group.append(row);
       });
 
       noteManagerList.append(group);
     });
+
+  const detailType = getNoteTypeById(selectedNote.typeId);
+  const previewText = getNotePreviewText(selectedNote);
+  const detailHeader = document.createElement("div");
+  detailHeader.className = "note-browser-detail-header";
+
+  const detailLabel = document.createElement("p");
+  detailLabel.className = "active-note-label";
+  detailLabel.textContent = detailType.name;
+
+  const detailTitle = document.createElement("h3");
+  detailTitle.className = "note-browser-detail-title";
+  detailTitle.textContent = getNoteDisplayTitle(selectedNote);
+
+  const detailMeta = document.createElement("p");
+  detailMeta.className = "note-browser-detail-meta";
+  detailMeta.textContent = `Created ${formatNoteDate(selectedNote.createdAt)} • Updated ${formatNoteDate(selectedNote.updatedAt)}`;
+
+  detailHeader.append(detailLabel, detailTitle, detailMeta);
+
+  const detailControls = document.createElement("div");
+  detailControls.className = "note-browser-detail-controls";
+
+  const typePicker = document.createElement("label");
+  typePicker.className = "field compact-field";
+
+  const typePickerLabel = document.createElement("span");
+  typePickerLabel.textContent = "Type";
+
+  const select = document.createElement("select");
+  select.dataset.noteMove = selectedNote.id;
+
+  workspace.noteTypes.forEach((type) => {
+    const option = document.createElement("option");
+    option.value = type.id;
+    option.textContent = type.name;
+    select.append(option);
+  });
+
+  select.value = selectedNote.typeId;
+  typePicker.append(typePickerLabel, select);
+
+  const actions = document.createElement("div");
+  actions.className = "note-browser-detail-actions";
+
+  const openButton = document.createElement("button");
+  openButton.type = "button";
+  openButton.className = "ghost-button";
+  openButton.dataset.noteAction = "open";
+  openButton.dataset.noteId = selectedNote.id;
+  openButton.textContent = "Open note";
+
+  const duplicateButton = document.createElement("button");
+  duplicateButton.type = "button";
+  duplicateButton.className = "ghost-button";
+  duplicateButton.dataset.noteAction = "duplicate";
+  duplicateButton.dataset.noteId = selectedNote.id;
+  duplicateButton.textContent = "Copy";
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "ghost-button";
+  deleteButton.dataset.noteAction = "delete";
+  deleteButton.dataset.noteId = selectedNote.id;
+  deleteButton.textContent = "Delete";
+
+  actions.append(openButton, duplicateButton, deleteButton);
+  detailControls.append(typePicker, actions);
+
+  const metadataBlock = document.createElement("div");
+  metadataBlock.className = "note-browser-detail-block";
+
+  const metadataTitle = document.createElement("p");
+  metadataTitle.className = "note-browser-detail-block-title";
+  metadataTitle.textContent = "Details";
+  metadataBlock.append(metadataTitle);
+
+  const populatedFields = detailType.fields
+    .map((field) => ({
+      label: field.label,
+      value: (selectedNote.metadata[field.id] ?? "").trim()
+    }))
+    .filter((field) => field.value);
+
+  if (populatedFields.length) {
+    const metadataList = document.createElement("div");
+    metadataList.className = "note-browser-detail-metadata";
+    populatedFields.forEach((field) => {
+      const chip = document.createElement("div");
+      chip.className = "metadata-chip";
+
+      const label = document.createElement("span");
+      label.className = "metadata-chip-label";
+      label.textContent = field.label;
+
+      const value = document.createElement("span");
+      value.className = "metadata-chip-value";
+      value.textContent = field.value;
+
+      chip.append(label, value);
+      metadataList.append(chip);
+    });
+    metadataBlock.append(metadataList);
+  } else {
+    const emptyMetadata = document.createElement("p");
+    emptyMetadata.className = "note-browser-empty";
+    emptyMetadata.textContent = "No note details added yet.";
+    metadataBlock.append(emptyMetadata);
+  }
+
+  const previewBlock = document.createElement("div");
+  previewBlock.className = "note-browser-detail-block";
+
+  const previewTitle = document.createElement("p");
+  previewTitle.className = "note-browser-detail-block-title";
+  previewTitle.textContent = "Preview";
+
+  const preview = document.createElement("p");
+  preview.className = "note-browser-detail-preview";
+  preview.textContent = previewText || "This note is still empty.";
+
+  previewBlock.append(previewTitle, preview);
+  noteBrowserDetails.append(detailHeader, detailControls, metadataBlock, previewBlock);
 };
 
 const renderProviderSettings = () => {
@@ -3030,6 +3138,7 @@ const refreshNoteSurfaces = () => {
 };
 
 const openNotesBrowser = () => {
+  noteBrowserSelectedNoteId = workspace.activeNoteId;
   renderNoteManager();
   overflowMenu.removeAttribute("open");
   openDialog(noteManagerDialog);
@@ -3638,17 +3747,18 @@ chapterSelect.addEventListener("change", () => {
 });
 
 noteManagerList.addEventListener("click", (event) => {
+  const selectionButton = event.target.closest("[data-note-select]");
+
+  if (selectionButton) {
+    noteBrowserSelectedNoteId = selectionButton.dataset.noteSelect;
+    renderNoteManager();
+  }
+});
+
+noteBrowserDetails.addEventListener("click", (event) => {
   const actionButton = event.target.closest("[data-note-action]");
 
   if (!actionButton) {
-    const row = event.target.closest(".note-manager-row");
-    const clickedInteractive = event.target.closest("button, select, input, label");
-
-    if (row && !clickedInteractive) {
-      switchNote(row.dataset.noteId);
-      noteManagerDialog.close();
-    }
-
     return;
   }
 
@@ -3662,6 +3772,7 @@ noteManagerList.addEventListener("click", (event) => {
 
   if (noteAction === "duplicate") {
     duplicateNote(noteId);
+    noteBrowserSelectedNoteId = workspace.activeNoteId;
     return;
   }
 
@@ -3670,7 +3781,7 @@ noteManagerList.addEventListener("click", (event) => {
   }
 });
 
-noteManagerList.addEventListener("change", (event) => {
+noteBrowserDetails.addEventListener("change", (event) => {
   const moveSelect = event.target.closest("[data-note-move]");
 
   if (!moveSelect) {

--- a/index.html
+++ b/index.html
@@ -173,7 +173,10 @@
             </select>
           </label>
         </div>
-        <div class="note-manager-list" id="note-manager-list"></div>
+        <div class="note-browser-layout">
+          <div class="note-manager-list" id="note-manager-list"></div>
+          <aside class="note-browser-details" id="note-browser-details"></aside>
+        </div>
       </div>
     </form>
   </dialog>

--- a/index.html
+++ b/index.html
@@ -52,19 +52,21 @@
                   <select id="note-type-select" name="note-type"></select>
                 </label>
                 <button class="ghost-button overflow-action" id="duplicate-note-button" type="button">Duplicate note</button>
-                <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Manage notes</button>
+                <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Browse notes</button>
                 <button class="ghost-button overflow-action" id="delete-note-button" type="button">Delete note</button>
               </div>
             </details>
           </div>
         </div>
 
-        <section class="note-switcher" aria-labelledby="note-list-title">
-          <div class="note-switcher-header">
-            <h3 id="note-list-title">Saved Notes</h3>
+        <div class="active-note-bar">
+          <div class="active-note-summary">
+            <p class="active-note-label">Current note</p>
+            <h3 class="active-note-title" id="active-note-title"></h3>
+            <p class="active-note-meta" id="active-note-meta"></p>
           </div>
-          <div class="note-list" id="note-list" role="listbox" aria-label="Saved notes"></div>
-        </section>
+          <button class="ghost-button subtle-button" id="browse-notes-button" type="button">Browse notes</button>
+        </div>
 
         <div class="note-meta-bar">
           <div class="metadata-summary" id="metadata-summary"></div>
@@ -146,13 +148,31 @@
     <form class="dialog-shell" method="dialog">
       <div class="dialog-header">
         <div>
-          <p class="panel-kicker">Manage Notes</p>
+          <p class="panel-kicker">Notes Browser</p>
           <h2>Notes Library</h2>
         </div>
         <button class="ghost-button" id="close-note-manager-button" type="submit">Close</button>
       </div>
 
       <div class="dialog-body">
+        <div class="note-browser-toolbar">
+          <label class="field compact-field note-browser-search">
+            <span>Filter</span>
+            <input id="note-browser-filter" type="search" placeholder="Search title, details, or note text">
+          </label>
+          <label class="field compact-field note-browser-type">
+            <span>Type</span>
+            <select id="note-browser-type-filter" name="note-browser-type-filter"></select>
+          </label>
+          <label class="field compact-field note-browser-sort">
+            <span>Sort</span>
+            <select id="note-browser-sort" name="note-browser-sort">
+              <option value="updated-desc">Recently updated</option>
+              <option value="created-desc">Recently created</option>
+              <option value="title-asc">Title</option>
+            </select>
+          </label>
+        </div>
         <div class="note-manager-list" id="note-manager-list"></div>
       </div>
     </form>

--- a/index.html
+++ b/index.html
@@ -36,15 +36,7 @@
             <details class="overflow-menu">
               <summary class="ghost-button">Actions ▾</summary>
               <div class="overflow-menu-panel">
-                <label class="field compact-field" id="new-note-type-field">
-                  <span>Type</span>
-                  <select id="new-note-type-select" name="new-note-type"></select>
-                </label>
-                <button class="ghost-button overflow-action" id="new-note-button" type="button">New note</button>
-                <label class="field compact-field" id="active-note-type-field">
-                  <span>Note type</span>
-                  <select id="note-type-select" name="note-type"></select>
-                </label>
+                <div id="new-note-actions"></div>
                 <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Browse notes</button>
                 <button class="ghost-button overflow-action" id="delete-note-button" type="button">Delete note</button>
               </div>
@@ -62,7 +54,7 @@
 
         <div class="note-meta-bar">
           <div class="metadata-summary" id="metadata-summary"></div>
-          <button class="ghost-button" id="note-details-button" type="button">Note details…</button>
+          <button class="ghost-button" id="note-details-button" type="button">Note options…</button>
         </div>
 
         <div class="toolbar" role="toolbar" aria-label="Rich text controls">
@@ -177,8 +169,8 @@
     <form class="dialog-shell compact-shell" method="dialog">
       <div class="dialog-header">
         <div>
-          <p class="panel-kicker">Note Details</p>
-          <h2>Metadata</h2>
+          <p class="panel-kicker">Note Options</p>
+          <h2>Edit Note Details</h2>
         </div>
         <button class="ghost-button" type="submit">Close</button>
       </div>

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
       </div>
       <div class="header-actions">
         <div class="header-controls">
-          <button class="theme-toggle" id="settings-button" type="button">
-            <span class="theme-toggle-label">Settings</span>
+            <button class="theme-toggle" id="settings-button" type="button">
+              <span class="theme-toggle-label">Settings…</span>
           </button>
         </div>
       </div>
@@ -34,7 +34,7 @@
           </div>
           <div class="note-actions">
             <details class="overflow-menu">
-              <summary class="ghost-button">Actions</summary>
+              <summary class="ghost-button">Actions ▾</summary>
               <div class="overflow-menu-panel">
                 <label class="field compact-field" id="new-note-type-field">
                   <span>Type</span>
@@ -62,7 +62,7 @@
 
         <div class="note-meta-bar">
           <div class="metadata-summary" id="metadata-summary"></div>
-          <button class="ghost-button" id="note-details-button" type="button">Note details</button>
+          <button class="ghost-button" id="note-details-button" type="button">Note details…</button>
         </div>
 
         <div class="toolbar" role="toolbar" aria-label="Rich text controls">

--- a/index.html
+++ b/index.html
@@ -33,25 +33,18 @@
             <h2 id="note-panel-title">Service Notes</h2>
           </div>
           <div class="note-actions">
-            <button class="ghost-button" id="new-note-direct-button" type="button">New note</button>
-            <details class="inline-action-menu" id="new-note-menu">
-              <summary class="ghost-button">New note</summary>
-              <div class="overflow-menu-panel inline-action-panel">
+            <details class="overflow-menu">
+              <summary class="ghost-button">Actions</summary>
+              <div class="overflow-menu-panel">
                 <label class="field compact-field" id="new-note-type-field">
                   <span>Type</span>
                   <select id="new-note-type-select" name="new-note-type"></select>
                 </label>
-                <button class="ghost-button overflow-action" id="new-note-button" type="button">Create note</button>
-              </div>
-            </details>
-            <details class="overflow-menu">
-              <summary class="ghost-button">More</summary>
-              <div class="overflow-menu-panel">
+                <button class="ghost-button overflow-action" id="new-note-button" type="button">New note</button>
                 <label class="field compact-field" id="active-note-type-field">
                   <span>Note type</span>
                   <select id="note-type-select" name="note-type"></select>
                 </label>
-                <button class="ghost-button overflow-action" id="duplicate-note-button" type="button">Duplicate note</button>
                 <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Browse notes</button>
                 <button class="ghost-button overflow-action" id="delete-note-button" type="button">Delete note</button>
               </div>
@@ -65,7 +58,6 @@
             <h3 class="active-note-title" id="active-note-title"></h3>
             <p class="active-note-meta" id="active-note-meta"></p>
           </div>
-          <button class="ghost-button subtle-button" id="browse-notes-button" type="button">Browse notes</button>
         </div>
 
         <div class="note-meta-bar">

--- a/styles.css
+++ b/styles.css
@@ -1093,6 +1093,34 @@ h1 {
   gap: 12px;
 }
 
+.note-browser-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1.1fr);
+  gap: 18px;
+  min-height: 0;
+}
+
+.note-manager-list,
+.note-browser-details {
+  min-height: 0;
+}
+
+.note-manager-list {
+  align-content: start;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.note-browser-details {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+}
+
 .note-browser-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1.5fr) minmax(180px, 0.8fr) minmax(180px, 0.8fr);
@@ -1154,36 +1182,6 @@ h1 {
   justify-content: flex-end;
 }
 
-.note-manager-row {
-  grid-template-columns: minmax(0, 1.4fr) minmax(180px, 0.8fr) auto auto auto;
-  align-items: center;
-  padding: 14px 16px;
-}
-
-.note-manager-row.is-active {
-  border-color: var(--tool-hover-border);
-  background: var(--note-chip-active);
-}
-
-.note-manager-summary {
-  display: grid;
-  gap: 4px;
-}
-
-.note-manager-title,
-.note-manager-meta {
-  display: block;
-}
-
-.note-manager-title {
-  font-weight: 700;
-}
-
-.note-manager-meta {
-  color: var(--muted);
-  font-size: 0.88rem;
-}
-
 .note-browser-group {
   display: grid;
   gap: 10px;
@@ -1220,6 +1218,105 @@ h1 {
   color: var(--muted);
   font-size: 0.95rem;
   padding: 8px 2px;
+}
+
+.note-browser-list-item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.note-browser-list-item:hover,
+.note-browser-list-item:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--tool-hover-border);
+  outline: none;
+}
+
+.note-browser-list-item.is-selected {
+  border-color: var(--tool-hover-border);
+  background: var(--note-chip-active);
+}
+
+.note-browser-list-title,
+.note-browser-list-meta {
+  display: block;
+}
+
+.note-browser-list-title {
+  font-weight: 700;
+}
+
+.note-browser-list-meta {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.note-browser-detail-header,
+.note-browser-detail-block {
+  display: grid;
+  gap: 8px;
+}
+
+.note-browser-detail-title,
+.note-browser-detail-meta,
+.note-browser-detail-block-title,
+.note-browser-detail-preview {
+  margin: 0;
+}
+
+.note-browser-detail-title {
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
+.note-browser-detail-meta {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.note-browser-detail-controls {
+  display: grid;
+  gap: 14px;
+}
+
+.note-browser-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.note-browser-detail-block {
+  padding-top: 4px;
+}
+
+.note-browser-detail-block-title {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.note-browser-detail-metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.note-browser-detail-preview {
+  color: var(--text);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .conflict-versions {
@@ -1296,8 +1393,8 @@ body.is-pane-dragging {
 
   .type-manager-layout,
   .settings-layout,
+  .note-browser-layout,
   .note-browser-toolbar,
-  .note-manager-row,
   .metadata-field-row,
   .display-field-grid,
   .alias-row {

--- a/styles.css
+++ b/styles.css
@@ -341,7 +341,10 @@ h1 {
 }
 
 .inline-action-menu > summary.overflow-action {
+  display: flex;
+  align-items: center;
   justify-content: center;
+  text-align: center;
 }
 
 .inline-action-panel {

--- a/styles.css
+++ b/styles.css
@@ -487,6 +487,52 @@ h1 {
   text-transform: uppercase;
 }
 
+.active-note-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  padding: 0 20px 14px;
+}
+
+.active-note-summary {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.active-note-label,
+.active-note-meta {
+  margin: 0;
+  color: var(--muted);
+}
+
+.active-note-label {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.active-note-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.active-note-meta {
+  font-size: 0.88rem;
+}
+
+.subtle-button {
+  color: var(--muted);
+}
+
+.subtle-button:hover,
+.subtle-button:focus-visible {
+  color: var(--text);
+}
+
 .note-meta-bar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -1047,6 +1093,13 @@ h1 {
   gap: 12px;
 }
 
+.note-browser-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(180px, 0.8fr) minmax(180px, 0.8fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
 .display-field-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1107,6 +1160,11 @@ h1 {
   padding: 14px 16px;
 }
 
+.note-manager-row.is-active {
+  border-color: var(--tool-hover-border);
+  background: var(--note-chip-active);
+}
+
 .note-manager-summary {
   display: grid;
   gap: 4px;
@@ -1124,6 +1182,44 @@ h1 {
 .note-manager-meta {
   color: var(--muted);
   font-size: 0.88rem;
+}
+
+.note-browser-group {
+  display: grid;
+  gap: 10px;
+}
+
+.note-browser-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 0 2px;
+}
+
+.note-browser-group-title,
+.note-browser-group-count {
+  margin: 0;
+}
+
+.note-browser-group-title {
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.note-browser-group-count {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.note-browser-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  padding: 8px 2px;
 }
 
 .conflict-versions {
@@ -1200,6 +1296,7 @@ body.is-pane-dragging {
 
   .type-manager-layout,
   .settings-layout,
+  .note-browser-toolbar,
   .note-manager-row,
   .metadata-field-row,
   .display-field-grid,
@@ -1218,11 +1315,22 @@ body.is-pane-dragging {
 
   .panel-header,
   .toolbar,
-  .note-switcher,
+  .active-note-bar,
+  .note-meta-bar,
   .note-meta,
   .verse-picker {
     padding-left: 18px;
     padding-right: 18px;
+  }
+
+  .active-note-bar,
+  .note-meta-bar {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .subtle-button {
+    justify-self: start;
   }
 
   .note-meta {

--- a/styles.css
+++ b/styles.css
@@ -885,6 +885,12 @@ h1 {
   max-height: calc(100vh - 64px);
 }
 
+#note-manager-dialog .dialog-shell {
+  height: min(760px, calc(100vh - 64px));
+  min-height: min(760px, calc(100vh - 64px));
+  max-height: calc(100vh - 64px);
+}
+
 #settings-dialog .dialog-shell {
   height: min(820px, calc(100vh - 64px));
   min-height: min(820px, calc(100vh - 64px));
@@ -909,6 +915,10 @@ h1 {
   min-height: 0;
   padding: 18px 20px 20px;
   overflow: auto;
+}
+
+#note-manager-dialog .dialog-body {
+  overflow: hidden;
 }
 
 #settings-dialog .dialog-body {
@@ -1102,6 +1112,7 @@ h1 {
   display: grid;
   grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1.1fr);
   gap: 18px;
+  height: 100%;
   min-height: 0;
 }
 
@@ -1124,6 +1135,7 @@ h1 {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--surface-strong);
+  overflow: auto;
 }
 
 .note-browser-toolbar {

--- a/styles.css
+++ b/styles.css
@@ -401,6 +401,20 @@ h1 {
   transition: transform 180ms ease, background 180ms ease;
 }
 
+.primary-button {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+  color: #fff;
+  font-weight: 700;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
 .note-switcher {
   padding: 0 20px 12px;
 }
@@ -522,15 +536,6 @@ h1 {
 
 .active-note-meta {
   font-size: 0.88rem;
-}
-
-.subtle-button {
-  color: var(--muted);
-}
-
-.subtle-button:hover,
-.subtle-button:focus-visible {
-  color: var(--text);
 }
 
 .note-meta-bar {
@@ -1424,10 +1429,6 @@ body.is-pane-dragging {
   .note-meta-bar {
     grid-template-columns: 1fr;
     align-items: start;
-  }
-
-  .subtle-button {
-    justify-self: start;
   }
 
   .note-meta {

--- a/styles.css
+++ b/styles.css
@@ -1114,6 +1114,7 @@ h1 {
   gap: 18px;
   height: 100%;
   min-height: 0;
+  padding-bottom: 8px;
 }
 
 .note-manager-list,
@@ -1125,6 +1126,7 @@ h1 {
   align-content: start;
   overflow: auto;
   padding-right: 4px;
+  padding-bottom: 16px;
 }
 
 .note-browser-details {
@@ -1136,6 +1138,7 @@ h1 {
   border-radius: var(--radius-lg);
   background: var(--surface-strong);
   overflow: auto;
+  padding-bottom: 24px;
 }
 
 .note-browser-toolbar {

--- a/styles.css
+++ b/styles.css
@@ -918,6 +918,8 @@ h1 {
 }
 
 #note-manager-dialog .dialog-body {
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
@@ -1111,8 +1113,8 @@ h1 {
 .note-browser-layout {
   display: grid;
   grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1.1fr);
+  flex: 1;
   gap: 18px;
-  height: 100%;
   min-height: 0;
   padding-bottom: 8px;
 }

--- a/styles.css
+++ b/styles.css
@@ -340,6 +340,10 @@ h1 {
   justify-content: flex-start;
 }
 
+.inline-action-menu > summary.overflow-action {
+  justify-content: center;
+}
+
 .inline-action-panel {
   min-width: 220px;
 }
@@ -592,6 +596,10 @@ h1 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
   padding: 0 20px 12px;
+}
+
+.note-meta-primary-field {
+  grid-column: 1 / -1;
 }
 
 .toolbar {


### PR DESCRIPTION
## Summary
- remove the horizontal note-card selector from the top of the notes pane
- add a compact active-note header with a subtle but visible `Browse notes` entry point
- turn the notes library dialog into a real browser with text filtering, type filtering, type grouping, and sort options
- keep note actions in-browser so notes can be opened, duplicated, deleted, or moved between note types from one place

## Verification
- code-reviewed the note switching, metadata updates, note creation, duplication, deletion, and type-change flows against the new browser render path
- not runtime-tested in a browser in this session
- attempted a JS parse check, but the available Node runtime is blocked by environment permissions