### PR TITLE
Add in-editor table editing controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,6 +85,13 @@ const firstSyncCancelButton = document.querySelector("#first-sync-cancel-button"
 const aboutVersionInfo = document.querySelector("#about-version-info");
 const mobileWarning = document.querySelector("#mobile-warning");
 const mobileWarningDismissButton = document.querySelector("#mobile-warning-dismiss");
+const insertTableButton = document.querySelector("#insert-table-button");
+const tableToolbar = document.querySelector("#table-toolbar");
+const tableDialog = document.querySelector("#table-dialog");
+const tableRowsInput = document.querySelector("#table-rows-input");
+const tableColumnsInput = document.querySelector("#table-columns-input");
+const tableInsertConfirmButton = document.querySelector("#table-insert-confirm-button");
+const tableContextMenu = document.querySelector("#table-context-menu");
 const insertImageButton = document.querySelector("#insert-image-button");
 const insertImageFile = document.querySelector("#insert-image-file");
 
@@ -194,6 +201,9 @@ let noteBrowserTypeFilter = "all";
 let noteBrowserSort = "updated-desc";
 let noteBrowserSelectedNoteId = null;
 let scriptureSearchQuery = "";
+let savedSelectionForTableInsert = null;
+let activeTableCell = null;
+let contextMenuTableCell = null;
 let dbPromise;
 let pendingAutoSyncTimer = null;
 let syncInFlightPromise = null;
@@ -2053,6 +2063,99 @@ const applyBlock = (block) => {
   document.execCommand("formatBlock", false, block);
 };
 
+const getEditorRange = () => {
+  const selection = window.getSelection();
+
+  if (!selection || !selection.rangeCount) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  return noteEditor.contains(range.commonAncestorContainer) ? range : null;
+};
+
+const saveEditorSelection = () => {
+  const range = getEditorRange();
+  return range ? range.cloneRange() : null;
+};
+
+const restoreEditorSelection = (savedRange) => {
+  if (!savedRange) {
+    return false;
+  }
+
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(savedRange);
+  return true;
+};
+
+const getClosestEditorElement = (node, selector) => {
+  if (!node) {
+    return null;
+  }
+
+  const element = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+  return element?.closest(selector) ?? null;
+};
+
+const ensureEditableCellContent = (cell) => {
+  if (!cell) {
+    return;
+  }
+
+  if (!cell.innerHTML.trim()) {
+    cell.innerHTML = "<br>";
+  }
+};
+
+const focusTableCell = (cell) => {
+  if (!cell) {
+    return;
+  }
+
+  ensureEditableCellContent(cell);
+  noteEditor.focus();
+  const range = document.createRange();
+  range.selectNodeContents(cell);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+const getTableCellFromSelection = () => {
+  const range = getEditorRange();
+
+  if (!range) {
+    return null;
+  }
+
+  const candidate = getClosestEditorElement(range.startContainer, "td, th");
+  return candidate && noteEditor.contains(candidate) ? candidate : null;
+};
+
+const getTableContext = (cell) => {
+  if (!cell) {
+    return null;
+  }
+
+  const table = cell.closest("table");
+  const row = cell.parentElement;
+
+  if (!table || !row) {
+    return null;
+  }
+
+  return {
+    cell,
+    row,
+    table,
+    rowIndex: [...table.rows].indexOf(row),
+    columnIndex: [...row.cells].indexOf(cell)
+  };
+};
+
 const getCaretTextOffset = (root) => {
   const selection = window.getSelection();
 
@@ -2776,6 +2879,227 @@ const insertImageAtCaret = (src, width = DEFAULT_IMAGE_EMBED_WIDTH) => {
   saveActiveNote();
 };
 
+const buildTableMarkup = (rows, columns, markerId) => {
+  const safeRows = Math.max(1, Math.min(20, rows));
+  const safeColumns = Math.max(1, Math.min(12, columns));
+  let body = "";
+
+  for (let rowIndex = 0; rowIndex < safeRows; rowIndex += 1) {
+    let cells = "";
+
+    for (let columnIndex = 0; columnIndex < safeColumns; columnIndex += 1) {
+      cells += "<td><br></td>";
+    }
+
+    body += `<tr>${cells}</tr>`;
+  }
+
+  return `<table class="note-table" data-table-marker="${markerId}"><tbody>${body}</tbody></table><p><br></p>`;
+};
+
+const closeTableContextMenu = () => {
+  tableContextMenu.hidden = true;
+  contextMenuTableCell = null;
+};
+
+const refreshTableUi = () => {
+  const currentCell = getTableCellFromSelection();
+  activeTableCell = currentCell;
+  tableToolbar.hidden = !currentCell;
+
+  if (!currentCell) {
+    closeTableContextMenu();
+  }
+};
+
+const insertTableAtSelection = (rows, columns) => {
+  noteEditor.focus();
+  const restoredSelection = restoreEditorSelection(savedSelectionForTableInsert);
+
+  if (!restoredSelection && !getEditorRange()) {
+    const range = document.createRange();
+    range.selectNodeContents(noteEditor);
+    range.collapse(false);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  const markerId = `table-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const currentTable = getTableCellFromSelection()?.closest("table");
+  let insertedTable = null;
+
+  if (currentTable && noteEditor.contains(currentTable)) {
+    const fragmentHost = document.createElement("div");
+    fragmentHost.innerHTML = buildTableMarkup(rows, columns, markerId);
+    const insertedNodes = [...fragmentHost.childNodes];
+    currentTable.after(...insertedNodes);
+    insertedTable = insertedNodes.find((node) => node.nodeName === "TABLE") ?? null;
+  } else {
+    document.execCommand("insertHTML", false, buildTableMarkup(rows, columns, markerId));
+    insertedTable = noteEditor.querySelector(`[data-table-marker="${markerId}"]`);
+  }
+
+  if (!insertedTable) {
+    saveActiveNote();
+    refreshTableUi();
+    return;
+  }
+
+  insertedTable.removeAttribute("data-table-marker");
+  const firstCell = insertedTable.rows[0]?.cells[0] ?? null;
+
+  if (firstCell) {
+    focusTableCell(firstCell);
+  }
+
+  savedSelectionForTableInsert = null;
+  saveActiveNote();
+  refreshTableUi();
+};
+
+const getTableActionContext = () => getTableContext(contextMenuTableCell ?? activeTableCell);
+
+const createEmptyParagraph = () => {
+  const paragraph = document.createElement("p");
+  paragraph.innerHTML = "<br>";
+  return paragraph;
+};
+
+const focusAfterTableRemoval = (table) => {
+  let focusTarget = table.nextElementSibling;
+
+  if (!focusTarget || !noteEditor.contains(focusTarget)) {
+    focusTarget = createEmptyParagraph();
+    table.after(focusTarget);
+  }
+
+  noteEditor.focus();
+  const range = document.createRange();
+  range.selectNodeContents(focusTarget);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+const insertTableRow = (context, offset) => {
+  const { table, rowIndex, columnIndex } = context;
+  const insertIndex = offset < 0 ? rowIndex : rowIndex + 1;
+  const columnCount = table.rows[0]?.cells.length ?? 0;
+  const row = table.insertRow(insertIndex);
+
+  for (let index = 0; index < columnCount; index += 1) {
+    const cell = row.insertCell();
+    cell.innerHTML = "<br>";
+  }
+
+  focusTableCell(row.cells[Math.min(columnIndex, row.cells.length - 1)] ?? row.cells[0] ?? null);
+};
+
+const deleteTableRow = (context) => {
+  const { table, rowIndex, columnIndex } = context;
+
+  if (table.rows.length <= 1) {
+    focusAfterTableRemoval(table);
+    table.remove();
+    return;
+  }
+
+  table.deleteRow(rowIndex);
+  const nextRow = table.rows[Math.min(rowIndex, table.rows.length - 1)];
+  focusTableCell(nextRow?.cells[Math.min(columnIndex, nextRow.cells.length - 1)] ?? nextRow?.cells[0] ?? null);
+};
+
+const insertTableColumn = (context, offset) => {
+  const { table, columnIndex, rowIndex } = context;
+  const insertIndex = offset < 0 ? columnIndex : columnIndex + 1;
+
+  [...table.rows].forEach((row) => {
+    const cell = row.insertCell(insertIndex);
+    cell.innerHTML = "<br>";
+  });
+
+  const targetRow = table.rows[rowIndex] ?? table.rows[0];
+  focusTableCell(targetRow?.cells[insertIndex] ?? null);
+};
+
+const deleteTableColumn = (context) => {
+  const { table, columnIndex, rowIndex } = context;
+  const columnCount = table.rows[0]?.cells.length ?? 0;
+
+  if (columnCount <= 1) {
+    focusAfterTableRemoval(table);
+    table.remove();
+    return;
+  }
+
+  [...table.rows].forEach((row) => {
+    if (row.cells[columnIndex]) {
+      row.deleteCell(columnIndex);
+    }
+  });
+
+  const targetRow = table.rows[Math.min(rowIndex, table.rows.length - 1)] ?? null;
+  const nextColumnIndex = Math.min(columnIndex, (targetRow?.cells.length ?? 1) - 1);
+  focusTableCell(targetRow?.cells[nextColumnIndex] ?? null);
+};
+
+const deleteTableAtContext = (context) => {
+  const { table } = context;
+  focusAfterTableRemoval(table);
+  table.remove();
+};
+
+const runTableAction = (action) => {
+  const context = getTableActionContext();
+
+  if (!context) {
+    return;
+  }
+
+  switch (action) {
+    case "insert-row-above":
+      insertTableRow(context, -1);
+      break;
+    case "insert-row-below":
+      insertTableRow(context, 1);
+      break;
+    case "delete-row":
+      deleteTableRow(context);
+      break;
+    case "insert-column-left":
+      insertTableColumn(context, -1);
+      break;
+    case "insert-column-right":
+      insertTableColumn(context, 1);
+      break;
+    case "delete-column":
+      deleteTableColumn(context);
+      break;
+    case "delete-table":
+      deleteTableAtContext(context);
+      break;
+    default:
+      return;
+  }
+
+  closeTableContextMenu();
+  saveActiveNote();
+  refreshTableUi();
+};
+
+const openTableContextMenu = (cell, x, y) => {
+  contextMenuTableCell = cell;
+  const margin = 12;
+  tableContextMenu.hidden = false;
+  const menuRect = tableContextMenu.getBoundingClientRect();
+  const maxX = window.innerWidth - menuRect.width - margin;
+  const maxY = window.innerHeight - menuRect.height - margin;
+  tableContextMenu.style.left = `${Math.max(margin, Math.min(x, maxX))}px`;
+  tableContextMenu.style.top = `${Math.max(margin, Math.min(y, maxY))}px`;
+};
+
 const processImageFiles = (files) => {
   [...files].forEach((file) => {
     if (!file.type.startsWith("image/")) {
@@ -3347,6 +3671,7 @@ const renderActiveNote = () => {
   linkifyScriptureReferences();
   linkifyUrls();
   processYouTubeEmbeds();
+  refreshTableUi();
 };
 
 const renderNoteManager = () => {
@@ -4410,6 +4735,24 @@ toolbarButtons.forEach((button) => {
   });
 });
 
+insertTableButton.addEventListener("click", () => {
+  savedSelectionForTableInsert = saveEditorSelection();
+  tableRowsInput.value = "3";
+  tableColumnsInput.value = "3";
+  openDialog(tableDialog);
+  window.setTimeout(() => {
+    tableRowsInput.focus();
+    tableRowsInput.select();
+  }, 0);
+});
+
+tableInsertConfirmButton.addEventListener("click", () => {
+  const rows = Number.parseInt(tableRowsInput.value, 10);
+  const columns = Number.parseInt(tableColumnsInput.value, 10);
+  tableDialog.close();
+  insertTableAtSelection(Number.isFinite(rows) ? rows : 3, Number.isFinite(columns) ? columns : 3);
+});
+
 // ── Color picker ───────────────────────────────────────────────────────
 const colorPickerWrapper = document.querySelector("#color-picker-wrapper");
 const colorPickerTrigger = document.querySelector("#color-picker-trigger");
@@ -4552,9 +4895,18 @@ document.addEventListener("click", (e) => {
   if (!overflowMenu.contains(e.target)) {
     closeOverflowMenu();
   }
+
+  if (!tableContextMenu.hidden && !tableContextMenu.contains(e.target)) {
+    closeTableContextMenu();
+  }
 });
 
 document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && !tableContextMenu.hidden) {
+    closeTableContextMenu();
+    return;
+  }
+
   if (e.key === "Escape" && !colorPickerDropdown.hidden) {
     closeColorPicker();
     colorPickerTrigger.focus();
@@ -4736,7 +5088,26 @@ noteEditor.addEventListener("drop", (event) => {
   processImageFiles(imageFiles);
 });
 
+[tableToolbar, tableContextMenu].forEach((container) => {
+  container.addEventListener("mousedown", (event) => {
+    if (event.target.closest("[data-table-action]")) {
+      event.preventDefault();
+    }
+  });
+
+  container.addEventListener("click", (event) => {
+    const actionButton = event.target.closest("[data-table-action]");
+
+    if (!actionButton) {
+      return;
+    }
+
+    runTableAction(actionButton.dataset.tableAction);
+  });
+});
+
 noteEditor.addEventListener("click", (event) => {
+  closeTableContextMenu();
   const imageDeleteBtn = event.target.closest(".image-embed-delete");
 
   if (imageDeleteBtn) {
@@ -4791,7 +5162,29 @@ noteEditor.addEventListener("click", (event) => {
 
   event.preventDefault();
   jumpToScripture(link.dataset.scriptureRef);
+  return;
 });
+
+noteEditor.addEventListener("contextmenu", (event) => {
+  const cell = event.target.closest("td, th");
+
+  if (!cell || !noteEditor.contains(cell)) {
+    closeTableContextMenu();
+    refreshTableUi();
+    return;
+  }
+
+  event.preventDefault();
+  focusTableCell(cell);
+  openTableContextMenu(cell, event.clientX, event.clientY);
+  refreshTableUi();
+});
+
+noteEditor.addEventListener("keyup", refreshTableUi);
+noteEditor.addEventListener("mouseup", refreshTableUi);
+noteEditor.addEventListener("scroll", closeTableContextMenu);
+
+document.addEventListener("selectionchange", refreshTableUi);
 
 noteEditor.addEventListener("mousedown", (event) => {
   const handle = event.target.closest(".youtube-embed-resize-handle");

--- a/app.js
+++ b/app.js
@@ -2905,7 +2905,7 @@ const closeTableContextMenu = () => {
 const refreshTableUi = () => {
   const currentCell = getTableCellFromSelection();
   activeTableCell = currentCell;
-  tableToolbar.hidden = !currentCell;
+  tableToolbar.toggleAttribute("hidden", !currentCell);
 
   if (!currentCell) {
     closeTableContextMenu();
@@ -4897,6 +4897,12 @@ document.addEventListener("click", (e) => {
   }
 
   if (!tableContextMenu.hidden && !tableContextMenu.contains(e.target)) {
+    closeTableContextMenu();
+  }
+});
+
+document.addEventListener("contextmenu", (event) => {
+  if (!tableContextMenu.hidden && !tableContextMenu.contains(event.target)) {
     closeTableContextMenu();
   }
 });

--- a/app.js
+++ b/app.js
@@ -2970,6 +2970,21 @@ const isLastTableCell = (context) => {
   return isLastRow && isLastColumn;
 };
 
+const getNextTableCell = (context) => {
+  if (!context) {
+    return null;
+  }
+
+  const nextCellInRow = context.row.cells[context.columnIndex + 1];
+
+  if (nextCellInRow) {
+    return nextCellInRow;
+  }
+
+  const nextRow = context.table.rows[context.rowIndex + 1];
+  return nextRow?.cells[0] ?? null;
+};
+
 const createEmptyParagraph = () => {
   const paragraph = document.createElement("p");
   paragraph.innerHTML = "<br>";
@@ -5009,13 +5024,20 @@ noteEditor.addEventListener("keydown", (event) => {
 
   const context = getTableContext(getTableCellFromSelection());
 
-  if (!isLastTableCell(context)) {
+  if (!context) {
     return;
   }
 
   event.preventDefault();
-  insertTableRow(context, 1, 0);
-  saveActiveNote();
+
+  if (isLastTableCell(context)) {
+    insertTableRow(context, 1, 0);
+    saveActiveNote();
+    refreshTableUi();
+    return;
+  }
+
+  focusTableCell(getNextTableCell(context));
   refreshTableUi();
 });
 

--- a/app.js
+++ b/app.js
@@ -2993,7 +2993,7 @@ const focusAfterTableRemoval = (table) => {
   selection.addRange(range);
 };
 
-const insertTableRow = (context, offset) => {
+const insertTableRow = (context, offset, focusColumnIndex = context.columnIndex) => {
   const { table, rowIndex, columnIndex } = context;
   const insertIndex = offset < 0 ? rowIndex : rowIndex + 1;
   const columnCount = table.rows[0]?.cells.length ?? 0;
@@ -3004,7 +3004,7 @@ const insertTableRow = (context, offset) => {
     cell.innerHTML = "<br>";
   }
 
-  focusTableCell(row.cells[Math.min(columnIndex, row.cells.length - 1)] ?? row.cells[0] ?? null);
+  focusTableCell(row.cells[Math.min(focusColumnIndex, row.cells.length - 1)] ?? row.cells[0] ?? null);
 };
 
 const deleteTableRow = (context) => {
@@ -5014,7 +5014,7 @@ noteEditor.addEventListener("keydown", (event) => {
   }
 
   event.preventDefault();
-  insertTableRow(context, 1);
+  insertTableRow(context, 1, 0);
   saveActiveNote();
   refreshTableUi();
 });

--- a/app.js
+++ b/app.js
@@ -5208,6 +5208,7 @@ noteEditor.addEventListener("contextmenu", (event) => {
   }
 
   event.preventDefault();
+  event.stopPropagation();
   focusTableCell(cell);
   openTableContextMenu(cell, event.clientX, event.clientY);
   refreshTableUi();

--- a/app.js
+++ b/app.js
@@ -2960,6 +2960,16 @@ const insertTableAtSelection = (rows, columns) => {
 
 const getTableActionContext = () => getTableContext(contextMenuTableCell ?? activeTableCell);
 
+const isLastTableCell = (context) => {
+  if (!context) {
+    return false;
+  }
+
+  const isLastRow = context.rowIndex === context.table.rows.length - 1;
+  const isLastColumn = context.columnIndex === context.row.cells.length - 1;
+  return isLastRow && isLastColumn;
+};
+
 const createEmptyParagraph = () => {
   const paragraph = document.createElement("p");
   paragraph.innerHTML = "<br>";
@@ -4990,6 +5000,23 @@ noteMetaFields.addEventListener("change", (event) => {
   }
 
   changeNoteType(typeSelect.dataset.noteTypeChange, typeSelect.value);
+});
+
+noteEditor.addEventListener("keydown", (event) => {
+  if (event.key !== "Tab" || event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
+    return;
+  }
+
+  const context = getTableContext(getTableCellFromSelection());
+
+  if (!isLastTableCell(context)) {
+    return;
+  }
+
+  event.preventDefault();
+  insertTableRow(context, 1);
+  saveActiveNote();
+  refreshTableUi();
 });
 
 noteEditor.addEventListener("input", (event) => {

--- a/index.html
+++ b/index.html
@@ -77,9 +77,21 @@
             </button>
             <div class="color-picker-dropdown" id="color-picker-dropdown" hidden role="dialog" aria-label="Text color"></div>
           </div>
+          <button class="tool-button" type="button" id="insert-table-button" aria-label="Insert table">Table</button>
           <button class="tool-button" type="button" id="insert-image-button" aria-label="Insert image">Image</button>
         </div>
         <input type="file" id="insert-image-file" accept="image/*" multiple hidden>
+
+        <div class="table-toolbar" id="table-toolbar" hidden aria-label="Table actions">
+          <span class="table-toolbar-label">Table</span>
+          <button class="ghost-button table-action-button" type="button" data-table-action="insert-row-above">Row above</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="insert-row-below">Row below</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="delete-row">Delete row</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="insert-column-left">Column left</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="insert-column-right">Column right</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="delete-column">Delete column</button>
+          <button class="ghost-button table-action-button" type="button" data-table-action="delete-table">Delete table</button>
+        </div>
 
         <div
           id="note-editor"
@@ -192,6 +204,35 @@
 
       <div class="dialog-body">
         <div class="note-meta details-meta" id="note-meta-fields"></div>
+      </div>
+    </form>
+  </dialog>
+
+  <dialog class="management-dialog compact-dialog" id="table-dialog">
+    <form class="dialog-shell compact-shell" method="dialog">
+      <div class="dialog-header">
+        <div>
+          <p class="panel-kicker">Editor</p>
+          <h2>Insert Table</h2>
+        </div>
+        <button class="ghost-button" type="submit">Close</button>
+      </div>
+
+      <div class="dialog-body">
+        <div class="table-insert-grid">
+          <label class="field">
+            <span>Rows</span>
+            <input id="table-rows-input" type="number" min="1" max="20" step="1" value="3">
+          </label>
+          <label class="field">
+            <span>Columns</span>
+            <input id="table-columns-input" type="number" min="1" max="12" step="1" value="3">
+          </label>
+        </div>
+        <div class="dialog-actions">
+          <button class="ghost-button" type="submit">Cancel</button>
+          <button class="ghost-button primary-button" id="table-insert-confirm-button" type="button">Insert table</button>
+        </div>
       </div>
     </form>
   </dialog>
@@ -379,6 +420,16 @@
       </div>
     </form>
   </dialog>
+
+  <div class="table-context-menu" id="table-context-menu" hidden role="menu" aria-label="Table actions">
+    <button class="table-context-menu-button" type="button" data-table-action="insert-row-above" role="menuitem">Insert row above</button>
+    <button class="table-context-menu-button" type="button" data-table-action="insert-row-below" role="menuitem">Insert row below</button>
+    <button class="table-context-menu-button" type="button" data-table-action="delete-row" role="menuitem">Delete row</button>
+    <button class="table-context-menu-button" type="button" data-table-action="insert-column-left" role="menuitem">Insert column left</button>
+    <button class="table-context-menu-button" type="button" data-table-action="insert-column-right" role="menuitem">Insert column right</button>
+    <button class="table-context-menu-button" type="button" data-table-action="delete-column" role="menuitem">Delete column</button>
+    <button class="table-context-menu-button is-destructive" type="button" data-table-action="delete-table" role="menuitem">Delete table</button>
+  </div>
 
   <dialog class="management-dialog compact-dialog" id="sync-conflict-dialog">
     <div class="dialog-shell compact-shell">

--- a/styles.css
+++ b/styles.css
@@ -616,6 +616,11 @@ h1 {
   padding: 0 20px 12px;
 }
 
+.table-toolbar[hidden],
+.table-context-menu[hidden] {
+  display: none !important;
+}
+
 .table-toolbar-label {
   font-size: 0.78rem;
   font-weight: 800;
@@ -918,10 +923,11 @@ h1 {
 }
 
 .note-table {
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   margin: 1rem 0;
   border-collapse: collapse;
-  table-layout: fixed;
+  table-layout: auto;
 }
 
 .note-table td,

--- a/styles.css
+++ b/styles.css
@@ -608,6 +608,26 @@ h1 {
   padding: 0 20px 12px;
 }
 
+.table-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 0 20px 12px;
+}
+
+.table-toolbar-label {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.table-action-button {
+  padding-inline: 0.9rem;
+}
+
 .tool-button {
   min-width: 48px;
   padding: 0.6rem 0.82rem;
@@ -895,6 +915,72 @@ h1 {
   padding-left: 1rem;
   border-left: 3px solid var(--blockquote-border);
   color: var(--blockquote-text);
+}
+
+.note-table {
+  width: 100%;
+  margin: 1rem 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.note-table td,
+.note-table th {
+  min-width: 5rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  vertical-align: top;
+}
+
+.note-table td:focus,
+.note-table th:focus,
+.note-table td:focus-visible,
+.note-table th:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.table-insert-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.table-context-menu {
+  position: fixed;
+  z-index: 200;
+  display: grid;
+  gap: 6px;
+  min-width: 210px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  box-shadow: var(--shadow);
+}
+
+.table-context-menu-button {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.table-context-menu-button:hover,
+.table-context-menu-button:focus-visible {
+  background: var(--tool-hover);
+  border-color: var(--tool-hover-border);
+  outline: none;
+}
+
+.table-context-menu-button.is-destructive {
+  color: var(--accent-strong);
 }
 
 .scripture-panel {


### PR DESCRIPTION
## Summary
- add table insertion to the note editor with a compact rows/columns dialog
- show contextual table actions when the caret is inside a table and support the same actions from a custom right-click menu
- style editor tables for inline editing and prevent accidental nested-table insertion

## Notes
- intentionally does not implement merged cells yet
- not runtime-verified in this session because both the bundled shell `node.exe` and the in-app browser runtime are blocked by local app permissions (`Access is denied`)
