### PR TITLE
Fix top spacing in note editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -2162,7 +2162,7 @@ const isEditorSpacerNode = (node) => {
   }
 
   if (node.nodeType === Node.TEXT_NODE) {
-    return !node.textContent.trim();
+    return !node.textContent.replace(/\u200b/g, "").trim();
   }
 
   if (node.nodeType !== Node.ELEMENT_NODE) {
@@ -2179,12 +2179,22 @@ const isEditorSpacerNode = (node) => {
     return false;
   }
 
-  const normalizedHtml = node.innerHTML
-    .replace(/&nbsp;/gi, "")
-    .replace(/\s+/g, "")
-    .toLowerCase();
+  if (node.querySelector("table, img, iframe, ul, ol, blockquote, h2, h3, h4, h5, h6")) {
+    return false;
+  }
 
-  return normalizedHtml === "" || normalizedHtml === "<br>" || normalizedHtml === "<br/>";
+  const textContent = node.textContent.replace(/\u200b/g, "").replace(/\u00a0/g, "").trim();
+
+  if (textContent) {
+    return false;
+  }
+
+  const htmlWithoutBreaks = node.innerHTML
+    .replace(/<br\s*\/?>/gi, "")
+    .replace(/&nbsp;/gi, "")
+    .replace(/\s+/g, "");
+
+  return htmlWithoutBreaks === "";
 };
 
 const trimEditorLeadingSpacerNodes = () => {
@@ -3730,6 +3740,7 @@ const renderActiveNote = () => {
   renderMetadataSummary();
   renderNoteMetadataFields();
   noteEditor.innerHTML = activeNote.content;
+  trimEditorLeadingSpacerNodes();
   linkifyScriptureReferences();
   linkifyUrls();
   processYouTubeEmbeds();
@@ -5080,6 +5091,8 @@ noteEditor.addEventListener("keydown", (event) => {
 });
 
 noteEditor.addEventListener("input", (event) => {
+  trimEditorLeadingSpacerNodes();
+
   if (event.inputType === "insertParagraph" || event.inputType === "insertLineBreak") {
     saveActiveNote();
     return;

--- a/app.js
+++ b/app.js
@@ -2156,6 +2156,43 @@ const getTableContext = (cell) => {
   };
 };
 
+const isEditorSpacerNode = (node) => {
+  if (!node) {
+    return false;
+  }
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    return !node.textContent.trim();
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
+
+  const tagName = node.tagName;
+
+  if (tagName === "BR") {
+    return true;
+  }
+
+  if (!["P", "DIV"].includes(tagName)) {
+    return false;
+  }
+
+  const normalizedHtml = node.innerHTML
+    .replace(/&nbsp;/gi, "")
+    .replace(/\s+/g, "")
+    .toLowerCase();
+
+  return normalizedHtml === "" || normalizedHtml === "<br>" || normalizedHtml === "<br/>";
+};
+
+const trimEditorLeadingSpacerNodes = () => {
+  while (isEditorSpacerNode(noteEditor.firstChild)) {
+    noteEditor.firstChild.remove();
+  }
+};
+
 const getCaretTextOffset = (root) => {
   const selection = window.getSelection();
 
@@ -4460,6 +4497,7 @@ const saveActiveNote = () => {
     return;
   }
 
+  trimEditorLeadingSpacerNodes();
   activeNote.content = noteEditor.innerHTML;
   noteMetaFields.querySelectorAll("[data-field-id]").forEach((input) => {
     activeNote.metadata[input.dataset.fieldId] = input.value;

--- a/index.html
+++ b/index.html
@@ -82,6 +82,16 @@
         </div>
         <input type="file" id="insert-image-file" accept="image/*" multiple hidden>
 
+        <div
+          id="note-editor"
+          class="note-editor"
+          contenteditable="true"
+          spellcheck="true"
+          role="textbox"
+          aria-multiline="true"
+          data-placeholder="Start typing sermon notes, key points, or prayer requests..."
+        ></div>
+
         <div class="table-toolbar" id="table-toolbar" hidden aria-label="Table actions">
           <span class="table-toolbar-label">Table</span>
           <button class="ghost-button table-action-button" type="button" data-table-action="insert-row-above">Row above</button>
@@ -92,16 +102,6 @@
           <button class="ghost-button table-action-button" type="button" data-table-action="delete-column">Delete column</button>
           <button class="ghost-button table-action-button" type="button" data-table-action="delete-table">Delete table</button>
         </div>
-
-        <div
-          id="note-editor"
-          class="note-editor"
-          contenteditable="true"
-          spellcheck="true"
-          role="textbox"
-          aria-multiline="true"
-          data-placeholder="Start typing sermon notes, key points, or prayer requests..."
-        ></div>
 
         <div class="panel-footer">
           <p id="save-status" class="save-status"></p>

--- a/styles.css
+++ b/styles.css
@@ -876,6 +876,24 @@ h1 {
   color: var(--placeholder);
 }
 
+.note-editor > :first-child {
+  margin-top: 0;
+}
+
+.note-editor > :last-child {
+  margin-bottom: 0;
+}
+
+.note-editor p,
+.note-editor div {
+  margin: 0 0 0.9em;
+}
+
+.note-editor ul,
+.note-editor ol {
+  margin: 0 0 0.9em 1.35em;
+}
+
 .panel-footer {
   padding: 0 20px 16px;
 }


### PR DESCRIPTION
## Summary
- normalize the top and bottom margins of the first and last blocks inside the note editor
- strip leading empty paragraph/div spacer nodes before persisting editor content so notes do not reopen with dead space at the top

## Notes
- this is aimed at the large top gap regression seen after the table-editor merge
- not runtime-verified in this session because the local browser/runtime hooks are currently blocked by app permissions here
