### PR TITLE
Refresh notes page layout and naming

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,8 +41,11 @@ const deleteNoteButton = document.querySelector("#delete-note-button");
 const manageNotesButton = document.querySelector("#manage-notes-button");
 const settingsButton = document.querySelector("#settings-button");
 const noteDetailsButton = document.querySelector("#note-details-button");
+const activeNoteLabel = document.querySelector("#active-note-label");
 const activeNoteTitle = document.querySelector("#active-note-title");
+const activeNoteEditButton = document.querySelector("#active-note-edit-button");
 const activeNoteMeta = document.querySelector("#active-note-meta");
+const noteMetaBar = document.querySelector("#note-meta-bar");
 const metadataSummary = document.querySelector("#metadata-summary");
 const noteMetaFields = document.querySelector("#note-meta-fields");
 const translationSelect = document.querySelector("#translation-select");
@@ -546,7 +549,7 @@ const buildMetadataForType = (type, sourceMetadata = {}, sourceType = null) => {
   return nextMetadata;
 };
 
-const getDefaultCardTitleFieldId = (type) => {
+const getSuggestedCardTitleFieldId = (type) => {
   const titleField = type.fields.find((field) => normalizeFieldLabel(field.label) === "title");
   return titleField?.id ?? type.fields[0]?.id ?? "";
 };
@@ -558,7 +561,7 @@ const getDefaultCardSubtitleFieldId = (type) => {
     return speakerField.id;
   }
 
-  const titleFieldId = getDefaultCardTitleFieldId(type);
+  const titleFieldId = getSuggestedCardTitleFieldId(type);
   const fallbackField = type.fields.find((field) => field.id !== titleFieldId);
   return fallbackField?.id ?? "";
 };
@@ -683,11 +686,15 @@ const ensureWorkspaceConsistency = () => {
         : []
     };
 
-    normalizedType.cardTitleFieldId = normalizedType.fields.some((field) => field.id === type.cardTitleFieldId)
-      ? type.cardTitleFieldId
-      : getDefaultCardTitleFieldId(normalizedType);
-    normalizedType.cardSubtitleFieldId = normalizedType.fields.some((field) => field.id === type.cardSubtitleFieldId)
-      ? type.cardSubtitleFieldId
+    normalizedType.cardTitleFieldId = typeof type.cardTitleFieldId === "string"
+      ? (type.cardTitleFieldId === "" || normalizedType.fields.some((field) => field.id === type.cardTitleFieldId)
+          ? type.cardTitleFieldId
+          : getSuggestedCardTitleFieldId(normalizedType))
+      : getSuggestedCardTitleFieldId(normalizedType);
+    normalizedType.cardSubtitleFieldId = typeof type.cardSubtitleFieldId === "string"
+      ? (type.cardSubtitleFieldId === "" || normalizedType.fields.some((field) => field.id === type.cardSubtitleFieldId)
+          ? type.cardSubtitleFieldId
+          : getDefaultCardSubtitleFieldId(normalizedType))
       : getDefaultCardSubtitleFieldId(normalizedType);
 
     return normalizedType;
@@ -3290,18 +3297,14 @@ const findAutoLinkAtCaret = () => {
 
 const getNoteDisplayTitle = (note) => {
   const type = getNoteTypeById(note.typeId);
-  const preferredField = type.fields.find((field) => field.id === type.cardTitleFieldId) ?? type.fields[0];
+  const preferredField = type.fields.find((field) => field.id === type.cardTitleFieldId) ?? null;
   const titleValue = preferredField ? note.metadata[preferredField.id]?.trim() : "";
 
   if (titleValue) {
     return titleValue;
   }
 
-  const anyValue = type.fields
-    .map((field) => note.metadata[field.id]?.trim())
-    .find(Boolean);
-
-  return anyValue || formatNoteDate(note.createdAt);
+  return formatNoteDate(note.createdAt);
 };
 
 const getNoteDisplayMeta = (note) => {
@@ -3426,18 +3429,19 @@ const renderMetadataSummary = () => {
 
   const populatedFields = type.fields
     .map((field) => ({
+      id: field.id,
       label: field.label,
       value: (activeNote.metadata[field.id] ?? "").trim()
     }))
-    .filter((field) => field.value);
+    .filter((field) => field.value)
+    .filter((field) => field.id !== type.cardTitleFieldId && field.id !== type.cardSubtitleFieldId);
 
   if (!populatedFields.length) {
-    const emptyState = document.createElement("p");
-    emptyState.className = "metadata-summary-empty";
-    emptyState.textContent = "No note details added yet.";
-    metadataSummary.append(emptyState);
+    noteMetaBar.classList.add("is-hidden");
     return;
   }
+
+  noteMetaBar.classList.remove("is-hidden");
 
   populatedFields.forEach((field) => {
     const chip = document.createElement("div");
@@ -3506,14 +3510,15 @@ const renderNoteMetadataFields = () => {
 const renderActiveNoteSummary = () => {
   const activeNote = getActiveNote();
   const type = getNoteTypeById(activeNote.typeId);
-  const metaBits = [type.name];
   const secondaryMeta = getNoteDisplayMeta(activeNote);
+  const metaBits = [];
 
   if (secondaryMeta) {
     metaBits.push(secondaryMeta);
   }
 
   metaBits.push(`Updated ${formatNoteDate(activeNote.updatedAt)}`);
+  activeNoteLabel.textContent = type.name || "Notes";
   activeNoteTitle.textContent = getNoteDisplayTitle(activeNote);
   activeNoteMeta.textContent = metaBits.join(" • ");
 };
@@ -4180,6 +4185,11 @@ const renderSettings = () => {
   cardTitleFieldSelect.innerHTML = "";
   cardSubtitleFieldSelect.innerHTML = "";
 
+  const noPrimaryOption = document.createElement("option");
+  noPrimaryOption.value = "";
+  noPrimaryOption.textContent = "None (use date)";
+  cardTitleFieldSelect.append(noPrimaryOption);
+
   const noneOption = document.createElement("option");
   noneOption.value = "";
   noneOption.textContent = "None";
@@ -4535,7 +4545,7 @@ const updateSelectedTypeCardFields = () => {
     return;
   }
 
-  type.cardTitleFieldId = cardTitleFieldSelect.value || getDefaultCardTitleFieldId(type);
+  type.cardTitleFieldId = cardTitleFieldSelect.value;
   type.cardSubtitleFieldId = cardSubtitleFieldSelect.value || "";
   persistWorkspace();
   renderWorkspace();
@@ -4595,7 +4605,7 @@ const removeMetadataField = (fieldId) => {
 
   type.fields = type.fields.filter((entry) => entry.id !== fieldId);
   if (type.cardTitleFieldId === fieldId) {
-    type.cardTitleFieldId = getDefaultCardTitleFieldId(type);
+    type.cardTitleFieldId = getSuggestedCardTitleFieldId(type);
   }
 
   if (type.cardSubtitleFieldId === fieldId) {
@@ -4882,6 +4892,11 @@ deleteNoteButton.addEventListener("click", () => {
   closeOverflowMenu();
 });
 noteDetailsButton.addEventListener("click", () => {
+  renderNoteMetadataFields();
+  openDialog(noteDetailsDialog);
+});
+
+activeNoteEditButton.addEventListener("click", () => {
   renderNoteMetadataFields();
   openDialog(noteDetailsDialog);
 });

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Service Notes</title>
+  <title>Notes</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&family=Manrope:wght@400;500;600;700&family=Orbitron:wght@400;700&family=Cinzel:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
@@ -18,8 +18,7 @@
   <div class="app-shell">
     <header class="app-header">
       <div>
-        <p class="eyebrow">Church Service Companion</p>
-        <h1>Sermon Notes</h1>
+        <h1>ChurchScribe</h1>
       </div>
       <div class="header-actions">
         <div class="header-controls">
@@ -31,11 +30,15 @@
     </header>
 
     <main class="pane-grid">
-      <section class="panel note-panel" aria-labelledby="note-panel-title">
+      <section class="panel note-panel" aria-labelledby="active-note-title">
         <div class="panel-header">
-          <div>
-            <p class="panel-kicker">Notebook</p>
-            <h2 id="note-panel-title">Service Notes</h2>
+          <div class="active-note-summary panel-note-summary">
+            <p class="active-note-label" id="active-note-label">Notes</p>
+            <div class="panel-note-title-row">
+              <h2 class="active-note-title panel-note-title" id="active-note-title"></h2>
+              <button class="panel-note-edit-button" id="active-note-edit-button" type="button" aria-label="Edit note options" title="Edit note options">✎</button>
+            </div>
+            <p class="active-note-meta panel-note-meta" id="active-note-meta"></p>
           </div>
           <div class="note-actions">
             <button class="ghost-button" id="note-details-button" type="button">Note options…</button>
@@ -50,15 +53,7 @@
           </div>
         </div>
 
-        <div class="active-note-bar">
-          <div class="active-note-summary">
-            <p class="active-note-label">Current note</p>
-            <h3 class="active-note-title" id="active-note-title"></h3>
-            <p class="active-note-meta" id="active-note-meta"></p>
-          </div>
-        </div>
-
-        <div class="note-meta-bar">
+        <div class="note-meta-bar" id="note-meta-bar">
           <div class="metadata-summary" id="metadata-summary"></div>
         </div>
 
@@ -89,7 +84,7 @@
           spellcheck="true"
           role="textbox"
           aria-multiline="true"
-          data-placeholder="Start typing sermon notes, key points, or prayer requests..."
+          data-placeholder="Start typing notes, key points, or prayer requests..."
         ></div>
 
         <div class="table-toolbar" id="table-toolbar" hidden aria-label="Table actions">
@@ -155,8 +150,8 @@
     <form class="dialog-shell" method="dialog">
       <div class="dialog-header">
         <div>
-          <p class="panel-kicker">Notes Browser</p>
-          <h2>Notes Library</h2>
+          <p class="panel-kicker">Library</p>
+          <h2>Notes</h2>
         </div>
         <button class="ghost-button" id="close-note-manager-button" type="submit">Close</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -126,8 +126,8 @@ body::before {
   display: flex;
   justify-content: space-between;
   gap: 20px;
-  align-items: end;
-  margin-bottom: 14px;
+  align-items: center;
+  margin-bottom: 12px;
 }
 
 .header-actions {
@@ -171,8 +171,8 @@ h3 {
 }
 
 h1 {
-  font-size: clamp(1.8rem, 3.8vw, 3.1rem);
-  max-width: 12ch;
+  font-size: clamp(1.7rem, 3vw, 2.45rem);
+  max-width: 14ch;
 }
 
 .header-copy {
@@ -270,10 +270,10 @@ h1 {
 
 .panel-header {
   display: flex;
-  align-items: center;
+  align-items: start;
   justify-content: space-between;
-  gap: 16px;
-  padding: 16px 20px 12px;
+  gap: 20px;
+  padding: 18px 20px 10px;
 }
 
 .panel-header h2 {
@@ -508,18 +508,21 @@ h1 {
   text-transform: uppercase;
 }
 
-.active-note-bar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 14px;
-  align-items: center;
-  padding: 0 20px 14px;
-}
-
 .active-note-summary {
   min-width: 0;
   display: grid;
-  gap: 4px;
+  gap: 6px;
+}
+
+.panel-note-summary {
+  padding-right: 12px;
+}
+
+.panel-note-title-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 100%;
 }
 
 .active-note-label,
@@ -529,31 +532,72 @@ h1 {
 }
 
 .active-note-label {
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .active-note-title {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.2;
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  line-height: 1.05;
+}
+
+.panel-note-title {
+  max-width: 22ch;
+}
+
+.panel-note-edit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--ghost-surface);
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.95rem;
+  line-height: 1;
+  opacity: 0;
+  transform: translateX(-6px);
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 160ms ease, color 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.panel-note-summary:hover .panel-note-edit-button,
+.panel-note-summary:focus-within .panel-note-edit-button,
+.panel-note-edit-button:focus-visible {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.panel-note-edit-button:hover,
+.panel-note-edit-button:focus-visible {
+  color: var(--text);
+  border-color: var(--tool-hover-border);
+  background: var(--surface-accent);
+  outline: none;
 }
 
 .active-note-meta {
-  font-size: 0.88rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 .note-meta-bar {
-  padding: 0 20px 12px;
+  padding: 0 20px 14px;
 }
 
 .metadata-summary {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  min-height: 44px;
   align-items: center;
 }
 
@@ -2266,17 +2310,11 @@ body.is-pane-dragging {
 
   .panel-header,
   .toolbar,
-  .active-note-bar,
   .note-meta-bar,
   .note-meta,
   .verse-picker {
     padding-left: 18px;
     padding-right: 18px;
-  }
-
-  .active-note-bar {
-    grid-template-columns: 1fr;
-    align-items: start;
   }
 
   .note-meta {


### PR DESCRIPTION
## Summary
- simplify the notes page header and standardize the top-level naming around Notes and ChurchScribe
- remove duplicated note metadata from the top chrome and add a hover pencil shortcut into Note Options
- allow note types to leave the primary line unset so note titles fall back to the note date

## Verification
- 
ode --check app.js

Closes #98