### PR TITLE
Rename app to Scriptoria and update all user-facing nomenclature

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,7 +131,9 @@ const tableContextMenu = document.querySelector("#table-context-menu");
 const insertImageButton = document.querySelector("#insert-image-button");
 const insertImageFile = document.querySelector("#insert-image-file");
 
-const dbName = "churchscribe-db";
+// TODO: Remove legacyDbName migration after a future release when the old name can be retired.
+const legacyDbName = "churchscribe-db";
+const dbName = "scriptoria-db";
 const dbVersion = 1;
 const dbStoreName = "kv";
 const workspaceStorageKey = "service-notes-workspace";
@@ -266,7 +268,7 @@ const settingsTabs = [
   },
   {
     id: "note-types",
-    label: "Note Types"
+    label: "Entry Types"
   },
   {
     id: "scripture-aliases",
@@ -274,15 +276,15 @@ const settingsTabs = [
   },
   {
     id: "cloud-sync",
-    label: "Auxiliary Storage"
+    label: "Sync & Backup"
   },
   {
     id: "translations",
-    label: "Translations"
+    label: "Bible Translations"
   },
   {
     id: "data",
-    label: "Data Management"
+    label: "Backup & Reset"
   },
   {
     id: "about",
@@ -293,22 +295,22 @@ const settingsTabs = [
 const onboardingSteps = [
   {
     kicker: "Welcome",
-    title: "ChurchScribe keeps your notes on your device",
-    copy: "ChurchScribe is designed to feel lightweight and private. Your notes live in your browser on your own computer unless you explicitly connect an auxiliary storage provider.",
+    title: "Scriptoria keeps your entries on your device",
+    copy: "Scriptoria is designed to feel lightweight and private. Your entries live in your browser on your own computer unless you explicitly connect a sync & backup provider.",
     points: [
-      "Nothing is automatically sent to a server run by ChurchScribe.",
+      "Nothing is automatically sent to a server run by Scriptoria.",
       "You stay in control of when and where any backups or sync copies are created.",
-      "You can clear or export your workspace later from Settings if you ever need to."
+      "You can clear or export your library later from Settings if you ever need to."
     ],
     callout: "Good to know: the default experience is local-first and privacy-friendly."
   },
   {
     kicker: "Taking Notes",
     title: "The note editor works like a focused writing surface",
-    copy: "Each note is its own editable document. Use the toolbar for quick formatting, lists, headings, quotes, images, and tables while you capture sermon points, study notes, or prayer requests.",
+    copy: "Each entry is its own editable document. Use the toolbar for quick formatting, lists, headings, quotes, images, and tables while you capture sermon points, study entries, or prayer requests.",
     points: [
-      "The main note area saves locally as you type.",
-      "Use the notes browser to jump between notes when your library grows.",
+      "The main entry area saves locally as you type.",
+      "Use the library to jump between entries when your library grows.",
       "Formatting is intentionally simple so you can stay in the flow during live note-taking."
     ],
     callout: "Tip: the app is optimized for desktop and tablet use, especially during active note-taking."
@@ -316,35 +318,35 @@ const onboardingSteps = [
   {
     kicker: "Scripture Linking",
     title: "Verse references are matched automatically",
-    copy: "When you type a Bible reference in your notes, ChurchScribe tries to recognize it and turn it into a clickable scripture link automatically.",
+    copy: "When you type a Bible reference in your entries, Scriptoria tries to recognize it and turn it into a clickable scripture link automatically.",
     points: [
-      "Matched references can jump you straight to the passage in the Scripture pane.",
+      "Matched references can jump you straight to the passage in the Scripture Panel.",
       "Common abbreviations are supported, and you can fine-tune them in Settings.",
-      "Copying verses from the Scripture pane keeps useful formatting like emphasis where possible."
+      "Copying verses from the Scripture Panel keeps useful formatting like emphasis where possible."
     ],
     callout: "If a book abbreviation is unusual in your church context, check the Scripture Abbreviations section in Settings."
   },
   {
-    kicker: "Note Types",
-    title: "Note types shape the details attached to each note",
-    copy: "ChurchScribe lets you define note types such as sermon notes, Bible studies, Sabbath School, or anything else you need. Each type can have its own metadata fields.",
+    kicker: "Entry Types",
+    title: "Entry types shape the details attached to each entry",
+    copy: "Scriptoria lets you define entry types such as sermon notes, Bible studies, Sabbath School, or anything else you need. Each type can have its own detail fields.",
     points: [
-      "Use Settings → Note Types to add, rename, or adjust note types.",
-      "Metadata fields can be customized to match the information you track most often.",
-      "The note options dialog lets you switch a note to a different type when that actually matters."
+      "Use Settings → Entry Types to add, rename, or adjust entry types.",
+      "Detail fields can be customized to match the information you track most often.",
+      "The entry details dialog lets you switch an entry to a different type when that actually matters."
     ],
-    callout: "This is one of the app’s best customization points: shape the workspace around your ministry context."
+    callout: "This is one of the app’s best customization points: shape the library around your ministry context."
   },
   {
     kicker: "Make It Yours",
     title: "Explore themes and optional cloud sync next",
-    copy: "Once the basics feel comfortable, check out the color themes and display settings, then consider connecting auxiliary storage if you want another copy of your notes outside this device.",
+    copy: "Once the basics feel comfortable, check out the color themes and display settings, then consider connecting sync & backup if you want another copy of your entries outside this device.",
     points: [
       "Themes and layout settings can make the app feel much more personal.",
-      "Auxiliary storage is optional, but useful if you want backup or cross-device workflows.",
+      "Sync & Backup is optional, but useful if you want backup or cross-device workflows.",
       "You can reopen this tutorial any time from Settings → About."
     ],
-    callout: "Recommended next steps: try a different theme, review your note types, and then decide whether cloud sync is worth setting up."
+    callout: "Recommended next steps: try a different theme, review your entry types, and then decide whether cloud sync is worth setting up."
   }
 ];
 
@@ -427,6 +429,69 @@ const openDatabase = () => {
   }
 
   return dbPromise;
+};
+
+// Copies all records from the legacy churchscribe-db into scriptoria-db on first run.
+// Only runs when the new database has no workspace data yet.
+// TODO: Remove this migration after a future release when churchscribe-db can be retired.
+const migrateFromLegacyDatabase = async () => {
+  if (typeof window.indexedDB.databases !== "function") {
+    return;
+  }
+
+  const databases = await window.indexedDB.databases();
+
+  if (!databases.some((db) => db.name === legacyDbName)) {
+    return;
+  }
+
+  const legacyDb = await new Promise((resolve) => {
+    const req = window.indexedDB.open(legacyDbName);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+
+  if (!legacyDb) {
+    return;
+  }
+
+  try {
+    if (!legacyDb.objectStoreNames.contains(dbStoreName)) {
+      return;
+    }
+
+    const records = await new Promise((resolve, reject) => {
+      const tx = legacyDb.transaction(dbStoreName, "readonly");
+      const req = tx.objectStore(dbStoreName).getAll();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+
+    if (!records.length) {
+      return;
+    }
+
+    const hasNewData = (await readStoredValue(workspaceStorageKey)) !== undefined;
+
+    if (hasNewData) {
+      return;
+    }
+
+    const newDb = await openDatabase();
+    await new Promise((resolve, reject) => {
+      const tx = newDb.transaction(dbStoreName, "readwrite");
+      const store = tx.objectStore(dbStoreName);
+      records.forEach((record) => store.put(record));
+      tx.oncomplete = resolve;
+      tx.onerror = () => reject(tx.error);
+    });
+
+    console.info("[Migration] Migrated data from churchscribe-db to scriptoria-db.");
+  } catch (err) {
+    console.error("[Migration] Failed to migrate from legacy database:", err);
+  } finally {
+    legacyDb.close();
+  }
 };
 
 const readStoredValue = async (key) => {
@@ -835,7 +900,7 @@ const restoreCloudSyncSettings = async () => {
 
 const buildCloudStatusText = () => {
   if (activeProvider.id === "none") {
-    return "No auxiliary provider configured";
+    return "No sync & backup provider configured";
   }
 
   const isLocalDrive = activeProvider.id === "local-drive";
@@ -1414,7 +1479,7 @@ const restoreWorkspace = async () => {
     workspace.updatedAt = savedWorkspace.updatedAt ?? null;
   } else if (savedNotes || legacyNotes) {
     migrateLegacyNotes(savedNotes ?? null, legacyNotes);
-    updateSaveStatus("Converted your existing notes into typed notes.");
+    updateSaveStatus("Converted your existing entries into typed entries.");
   } else {
     const defaultType = createDefaultNoteType();
     workspace.noteTypes = [defaultType];
@@ -3408,7 +3473,7 @@ const renderNoteTypeOptions = () => {
     singleTypeButton.type = "button";
     singleTypeButton.className = "ghost-button overflow-action";
     singleTypeButton.dataset.newNoteType = workspace.noteTypes[0].id;
-    singleTypeButton.textContent = "New note";
+    singleTypeButton.textContent = "New entry";
     newNoteActions.append(singleTypeButton);
     return;
   }
@@ -3418,7 +3483,7 @@ const renderNoteTypeOptions = () => {
 
   const summary = document.createElement("summary");
   summary.className = "ghost-button overflow-action";
-  summary.textContent = "New note ▾";
+  summary.textContent = "New entry ▾";
 
   const panel = document.createElement("div");
   panel.className = "overflow-menu-panel inline-action-panel";
@@ -3484,7 +3549,7 @@ const renderNoteMetadataFields = () => {
     typeField.className = "field note-meta-primary-field";
 
     const typeLabel = document.createElement("span");
-    typeLabel.textContent = "Note type";
+    typeLabel.textContent = "Entry type";
 
     const typeSelect = document.createElement("select");
     typeSelect.name = "active-note-type";
@@ -3532,7 +3597,7 @@ const renderActiveNoteSummary = () => {
   }
 
   metaBits.push(`Updated ${formatNoteDate(activeNote.updatedAt)}`);
-  activeNoteLabel.textContent = type.name || "Notes";
+  activeNoteLabel.textContent = type.name || "Entries";
   activeNoteTitle.textContent = getNoteDisplayTitle(activeNote);
   activeNoteMeta.textContent = metaBits.join(" • ");
 };
@@ -3575,7 +3640,7 @@ const renderNoteManager = () => {
   noteBrowserTypeFilterSelect.innerHTML = "";
   const allOption = document.createElement("option");
   allOption.value = "all";
-  allOption.textContent = "All note types";
+  allOption.textContent = "All entry types";
   noteBrowserTypeFilterSelect.append(allOption);
   workspace.noteTypes.forEach((type) => {
     const option = document.createElement("option");
@@ -3593,8 +3658,8 @@ const renderNoteManager = () => {
     const emptyState = document.createElement("p");
     emptyState.className = "note-browser-empty";
     emptyState.textContent = noteBrowserFilter || noteBrowserTypeFilter !== "all"
-      ? "No notes match the current filter."
-      : "No notes available.";
+      ? "No entries match the current filter."
+      : "No entries available.";
     noteManagerList.append(emptyState);
     noteBrowserSelectedNoteId = null;
     return;
@@ -3621,7 +3686,7 @@ const renderNoteManager = () => {
 
       const count = document.createElement("span");
       count.className = "note-browser-group-count";
-      count.textContent = `${notes.length} note${notes.length === 1 ? "" : "s"}`;
+      count.textContent = `${notes.length} entr${notes.length === 1 ? "y" : "ies"}`;
 
       groupHeader.append(heading, count);
       group.append(groupHeader);
@@ -3677,7 +3742,7 @@ const renderNoteManager = () => {
         openButton.className = "ghost-button primary-button";
         openButton.dataset.noteAction = "open";
         openButton.dataset.noteId = selectedNote.id;
-        openButton.textContent = "Open note";
+        openButton.textContent = "Open";
 
   const duplicateButton = document.createElement("button");
   duplicateButton.type = "button";
@@ -3732,7 +3797,7 @@ const renderNoteManager = () => {
   } else {
     const emptyMetadata = document.createElement("p");
     emptyMetadata.className = "note-browser-empty";
-    emptyMetadata.textContent = "No note details added yet.";
+    emptyMetadata.textContent = "No entry details added yet.";
     metadataBlock.append(emptyMetadata);
   }
 
@@ -3745,7 +3810,7 @@ const renderNoteManager = () => {
 
   const preview = document.createElement("p");
   preview.className = "note-browser-detail-preview";
-  preview.textContent = previewText || "This note is still empty.";
+  preview.textContent = previewText || "This entry is still empty.";
 
   previewBlock.append(previewTitle, preview);
   noteBrowserDetails.append(detailHeader, actions, metadataBlock, previewBlock);
@@ -3920,7 +3985,7 @@ const renderUiSettings = (container) => {
 const downloadWorkspaceBackup = () => {
   const exportedAt = new Date().toISOString();
   const backup = {
-    type: "churchscribe-backup",
+    type: "scriptoria-backup",
     version: 1,
     exportedAt,
     workspace: {
@@ -3944,7 +4009,7 @@ const downloadWorkspaceBackup = () => {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `churchscribe-backup-${exportedAt.split("T")[0]}.json`;
+  a.download = `scriptoria-backup-${exportedAt.split("T")[0]}.json`;
   document.body.append(a);
   a.click();
   a.remove();
@@ -3961,11 +4026,11 @@ const restoreWorkspaceFromBackup = async (file) => {
     }
 
     if (!backup.workspace || !Array.isArray(backup.notes)) {
-      throw new Error("The selected file does not appear to be a ChurchScribe backup.");
+      throw new Error("The selected file does not appear to be a Scriptoria backup.");
     }
 
     // eslint-disable-next-line no-alert
-    if (!window.confirm("This will replace your current workspace with the backup. Your existing data will be overwritten. Continue?")) {
+    if (!window.confirm("This will replace your current library with the backup. Your existing data will be overwritten. Continue?")) {
       return;
     }
 
@@ -4026,7 +4091,7 @@ const restoreWorkspaceFromBackup = async (file) => {
     buildBookAliasMap();
     renderWorkspace();
     persistWorkspace();
-    updateSaveStatus("Workspace restored from backup.");
+    updateSaveStatus("Library restored from backup.");
   } catch (error) {
     console.error("[Backup] Restore failed:", error);
     // eslint-disable-next-line no-alert
@@ -4036,7 +4101,7 @@ const restoreWorkspaceFromBackup = async (file) => {
 
 const clearLocalWorkspace = async () => {
   // eslint-disable-next-line no-alert
-  if (!window.confirm("This will permanently delete all local notes, note types, and settings. The app will reset to its default state. This cannot be undone.")) {
+  if (!window.confirm("This will permanently delete all local entries, entry types, and settings. The app will reset to its default state. This cannot be undone.")) {
     return;
   }
 
@@ -4069,12 +4134,12 @@ const clearLocalWorkspace = async () => {
 const clearRemoteWorkspace = async () => {
   if (!activeProvider.hasActiveSession()) {
     // eslint-disable-next-line no-alert
-    window.alert("No storage provider is connected. Connect a provider in Auxiliary Storage settings first.");
+    window.alert("No storage provider is connected. Connect a provider in Sync & Backup settings first.");
     return;
   }
 
   // eslint-disable-next-line no-alert
-  if (!window.confirm(`This will permanently delete all workspace data stored on ${activeProvider.displayName}. Your local workspace will not be affected. This cannot be undone.`)) {
+  if (!window.confirm(`This will permanently delete all library data stored on ${activeProvider.displayName}. Your local library will not be affected. This cannot be undone.`)) {
     return;
   }
 
@@ -4092,7 +4157,7 @@ const clearRemoteWorkspace = async () => {
   } catch (error) {
     console.error("[Data] Clear remote failed:", error);
     // eslint-disable-next-line no-alert
-    window.alert(`Failed to clear remote workspace: ${error.message}`);
+    window.alert(`Failed to clear remote library: ${error.message}`);
   }
 };
 
@@ -4494,7 +4559,7 @@ const deleteNoteById = (noteId) => {
     return;
   }
 
-  const confirmed = window.confirm(`Delete note "${getNoteDisplayTitle(note)}"? This cannot be undone.`);
+  const confirmed = window.confirm(`Delete entry "${getNoteDisplayTitle(note)}"? This cannot be undone.`);
 
   if (!confirmed) {
     return;
@@ -4669,12 +4734,12 @@ const deleteSelectedType = () => {
   const type = getSelectedTypeForManager();
 
   if (!type || workspace.noteTypes.length === 1) {
-    window.alert("At least one note type is required.");
+    window.alert("At least one entry type is required.");
     return;
   }
 
   const replacementType = workspace.noteTypes.find((entry) => entry.id !== type.id);
-  const confirmed = window.confirm(`Delete note type "${type.name}" and move its notes to "${replacementType.name}"?`);
+  const confirmed = window.confirm(`Delete entry type "${type.name}" and move its entries to "${replacementType.name}"?`);
 
   if (!confirmed) {
     return;
@@ -5476,7 +5541,7 @@ noteEditor.addEventListener("dragstart", (event) => {
 
   event.dataTransfer.effectAllowed = "move";
   event.dataTransfer.setData("text/html", embed.outerHTML);
-  event.dataTransfer.setData("application/x-churchscribe-embed", "true");
+  event.dataTransfer.setData("application/x-scriptoria-embed", "true");
   embed.dataset.embedDragging = "true";
 });
 
@@ -5489,7 +5554,10 @@ noteEditor.addEventListener("dragend", () => {
 noteEditor.addEventListener("dragover", (event) => {
   const types = [...event.dataTransfer.types];
 
-  if (types.includes("Files") || types.includes("application/x-churchscribe-embed")) {
+  // TODO: Remove application/x-churchscribe-embed fallback after a future release.
+  const isEmbedDrag = types.includes("application/x-scriptoria-embed") || types.includes("application/x-churchscribe-embed");
+
+  if (types.includes("Files") || isEmbedDrag) {
     event.preventDefault();
     event.dataTransfer.dropEffect = types.includes("Files") ? "copy" : "move";
   }
@@ -5520,7 +5588,8 @@ noteEditor.addEventListener("drop", (event) => {
   };
 
   // ── Embed-move drop ──────────────────────────────────────────────────────
-  if (types.includes("application/x-churchscribe-embed")) {
+  // TODO: Remove application/x-churchscribe-embed fallback after a future release.
+  if (types.includes("application/x-scriptoria-embed") || types.includes("application/x-churchscribe-embed")) {
     event.preventDefault();
 
     const embedHtml = event.dataTransfer.getData("text/html");
@@ -6537,6 +6606,7 @@ const buildBookAliasMap = () => {
 };
 
 const bootstrap = async () => {
+  await migrateFromLegacyDatabase();
   await loadCustomTranslations();
   populateTranslationSelect();
   applyThemeMode(await getPreferredTheme(), { rerender: false });

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Notes</title>
+  <title>Scriptoria</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&family=Manrope:wght@400;500;600;700&family=Orbitron:wght@400;700&family=Cinzel:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
@@ -11,14 +11,14 @@
 </head>
 <body>
   <div class="mobile-warning" id="mobile-warning" role="alert">
-    <p class="mobile-warning-text">ChurchScribe is designed for desktops and tablets — it may not work well on a small screen.</p>
+    <p class="mobile-warning-text">Scriptoria is designed for desktops and tablets — it may not work well on a small screen.</p>
     <button class="mobile-warning-dismiss" id="mobile-warning-dismiss" type="button" aria-label="Dismiss warning">✕</button>
   </div>
 
   <div class="app-shell">
     <header class="app-header">
       <div>
-        <h1>ChurchScribe</h1>
+        <h1>Scriptoria</h1>
       </div>
       <div class="header-actions">
         <div class="header-controls">
@@ -33,21 +33,21 @@
       <section class="panel note-panel" aria-labelledby="active-note-title">
         <div class="panel-header">
           <div class="active-note-summary panel-note-summary">
-            <p class="active-note-label" id="active-note-label">Notes</p>
+            <p class="active-note-label" id="active-note-label">Entries</p>
             <div class="panel-note-title-row">
               <h2 class="active-note-title panel-note-title" id="active-note-title"></h2>
-              <button class="panel-note-edit-button" id="active-note-edit-button" type="button" aria-label="Edit note options" title="Edit note options">✎</button>
+              <button class="panel-note-edit-button" id="active-note-edit-button" type="button" aria-label="Edit entry details" title="Edit entry details">✎</button>
             </div>
             <p class="active-note-meta panel-note-meta" id="active-note-meta"></p>
           </div>
           <div class="note-actions">
-            <button class="ghost-button" id="note-details-button" type="button">Note options…</button>
+            <button class="ghost-button" id="note-details-button" type="button">Entry Details…</button>
             <details class="overflow-menu">
               <summary class="ghost-button">Actions ▾</summary>
               <div class="overflow-menu-panel">
                 <div id="new-note-actions"></div>
-                <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Browse notes</button>
-                <button class="ghost-button overflow-action" id="delete-note-button" type="button">Delete note</button>
+                <button class="ghost-button overflow-action" id="manage-notes-button" type="button">Open Library</button>
+                <button class="ghost-button overflow-action" id="delete-note-button" type="button">Delete entry</button>
               </div>
             </details>
           </div>
@@ -84,7 +84,7 @@
           spellcheck="true"
           role="textbox"
           aria-multiline="true"
-          data-placeholder="Start typing notes, key points, or prayer requests..."
+          data-placeholder="Start writing sermon notes, study thoughts, or scripture reflections..."
         ></div>
 
         <div class="table-toolbar" id="table-toolbar" hidden aria-label="Table actions">
@@ -109,7 +109,7 @@
         <div class="panel-header">
           <div>
             <p class="panel-kicker">Scripture</p>
-            <h2 id="scripture-panel-title">Bible Verses</h2>
+            <h2 id="scripture-panel-title">Scriptures</h2>
           </div>
         </div>
 
@@ -131,7 +131,7 @@
 
           <label class="field verse-search-field">
             <span>Search</span>
-            <input type="search" id="scripture-search-input" placeholder="Search verses…" autocomplete="off">
+            <input type="search" id="scripture-search-input" placeholder="Scripture Search…" autocomplete="off">
           </label>
         </form>
 
@@ -151,7 +151,7 @@
       <div class="dialog-header">
         <div>
           <p class="panel-kicker">Library</p>
-          <h2>Notes</h2>
+          <h2>Entries</h2>
         </div>
         <button class="ghost-button" id="close-note-manager-button" type="submit">Close</button>
       </div>
@@ -160,7 +160,7 @@
         <div class="note-browser-toolbar">
           <label class="field compact-field note-browser-search">
             <span>Filter</span>
-            <input id="note-browser-filter" type="search" placeholder="Search title, details, or note text">
+            <input id="note-browser-filter" type="search" placeholder="Search entries, details or content">
           </label>
           <label class="field compact-field note-browser-type">
             <span>Type</span>
@@ -187,8 +187,8 @@
     <form class="dialog-shell compact-shell" method="dialog">
       <div class="dialog-header">
         <div>
-          <p class="panel-kicker">Note Options</p>
-          <h2>Edit Note Details</h2>
+          <p class="panel-kicker">Entry Details</p>
+          <h2>Edit Entry Details</h2>
         </div>
         <button class="ghost-button" type="submit">Close</button>
       </div>
@@ -232,7 +232,7 @@
       <div class="dialog-header">
         <div>
           <p class="panel-kicker">Settings</p>
-          <h2>Workspace Settings</h2>
+          <h2>Library Settings</h2>
         </div>
         <button class="ghost-button" id="close-settings-button" type="submit">Close</button>
       </div>
@@ -244,18 +244,18 @@
           <div class="note-switcher-header">
             <h3 id="ui-settings-title">Display Settings</h3>
           </div>
-          <p class="settings-copy">Control how ChurchScribe looks and behaves.</p>
+          <p class="settings-copy">Control how Scriptoria looks and behaves.</p>
           <div id="ui-settings-content"></div>
         </section>
 
         <section class="type-editor-panel settings-type-editor" data-settings-panel="note-types" aria-labelledby="type-editor-title">
           <div class="note-switcher-header">
-            <h3 id="type-editor-title">Note Types</h3>
+            <h3 id="type-editor-title">Entry Types</h3>
             <button class="ghost-button" id="add-type-button" type="button">Add type</button>
           </div>
 
           <div class="type-editor-empty" id="type-editor-empty">
-            <p>Select a type to edit its name and metadata fields.</p>
+            <p>Select a type to edit its name and detail fields.</p>
           </div>
 
           <div class="type-editor-form" id="type-editor-form" hidden>
@@ -271,15 +271,15 @@
 
             <div class="display-field-editor">
               <div class="note-switcher-header">
-                <h3>Note Card Fields</h3>
+                <h3>Entry Card Fields</h3>
               </div>
               <div class="display-field-grid">
                 <label class="field">
-                  <span>Primary Line</span>
+                  <span>Library Title</span>
                   <select id="card-title-field-select" name="card-title-field"></select>
                 </label>
                 <label class="field">
-                  <span>Secondary Line</span>
+                  <span>Library Subtitle</span>
                   <select id="card-subtitle-field-select" name="card-subtitle-field"></select>
                 </label>
               </div>
@@ -287,7 +287,7 @@
 
             <div class="metadata-field-editor">
               <div class="note-switcher-header">
-                <h3>Metadata Fields</h3>
+                <h3>Detail Fields</h3>
                 <button class="ghost-button" id="add-metadata-field-button" type="button">Add field</button>
               </div>
               <div class="metadata-field-list" id="metadata-field-list"></div>
@@ -303,13 +303,13 @@
           <div class="note-switcher-header">
             <h3 id="alias-editor-title">Scripture Abbreviations</h3>
           </div>
-          <p class="settings-copy">Add comma-separated aliases like `Jn, Jon` for each book. These are used when linking references in notes.</p>
+          <p class="settings-copy">Add comma-separated aliases like `Jn, Jon` for each book. These are used when linking references in entries.</p>
           <div class="alias-list" id="alias-list"></div>
         </section>
 
         <section class="type-editor-panel settings-cloud-panel" data-settings-panel="cloud-sync" aria-labelledby="cloud-sync-title">
           <div class="note-switcher-header">
-            <h3 id="cloud-sync-title">Auxiliary Storage</h3>
+            <h3 id="cloud-sync-title">Sync &amp; Backup</h3>
           </div>
           <p class="settings-copy">Configure where your data is stored in addition to your browser's local IndexedDB. Choose a cloud provider or a local folder on your system.</p>
 
@@ -396,11 +396,11 @@
           <div class="note-switcher-header">
             <h3 id="data-title">Data Management</h3>
           </div>
-          <p class="settings-copy">Back up your workspace to a file, restore from a previous backup, or reset the app to its default state.</p>
+          <p class="settings-copy">Back up your library to a file, restore from a previous backup, or reset the app to its default state.</p>
 
           <div class="data-management-section">
             <h4 class="data-section-title">Backup &amp; Restore</h4>
-            <p class="settings-copy">Download a snapshot of your notes, note types, and preferences as a JSON file. You can restore it at any time.</p>
+            <p class="settings-copy">Download a snapshot of your entries, entry types, and preferences as a JSON file. You can restore it at any time.</p>
             <div class="dialog-actions data-actions">
               <button class="ghost-button" id="download-backup-button" type="button">Download Backup</button>
               <button class="ghost-button" id="restore-backup-button" type="button">Restore from Backup…</button>
@@ -410,10 +410,10 @@
 
           <div class="data-management-section data-management-section--danger">
             <h4 class="data-section-title">Reset</h4>
-            <p class="settings-copy">Permanently erase workspace data. Choose what to reset: data stored in this browser, data stored on your connected auxiliary storage provider, or both. These actions cannot be undone.</p>
+            <p class="settings-copy">Permanently erase library data. Choose what to reset: data stored in this browser, data stored on your connected sync &amp; backup provider, or both. These actions cannot be undone.</p>
             <div class="dialog-actions data-actions">
-              <button class="ghost-button ghost-button--danger" id="clear-local-button" type="button">Clear Local Workspace…</button>
-              <button class="ghost-button ghost-button--danger" id="clear-remote-button" type="button">Clear Remote Workspace…</button>
+              <button class="ghost-button ghost-button--danger" id="clear-local-button" type="button">Clear Local Library…</button>
+              <button class="ghost-button ghost-button--danger" id="clear-remote-button" type="button">Clear Remote Library…</button>
               <button class="ghost-button ghost-button--danger" id="clear-all-button" type="button">Clear All Data…</button>
             </div>
           </div>
@@ -421,9 +421,9 @@
 
         <section class="type-editor-panel settings-about-panel" data-settings-panel="about" aria-labelledby="about-title">
           <div class="note-switcher-header">
-            <h3 id="about-title">About ChurchScribe</h3>
+            <h3 id="about-title">About Scriptoria</h3>
           </div>
-          <p class="settings-copy">ChurchScribe is a lightweight, privacy-friendly sermon and Bible-study note-taking tool that runs entirely in your browser.</p>
+          <p class="settings-copy">Scriptoria is a lightweight, privacy-friendly sermon and Bible-study note-taking tool that runs entirely in your browser.</p>
           <div class="about-credits">
             <p class="settings-copy">Created by <strong>Josh Penman</strong> (<a class="about-link" href="https://github.com/KiwiGeek" target="_blank" rel="noopener noreferrer">@KiwiGeek</a>).</p>
             <p class="settings-copy about-version" id="about-version-info"></p>
@@ -451,7 +451,7 @@
       <div class="dialog-header">
         <div>
           <p class="panel-kicker" id="onboarding-step-kicker">Welcome</p>
-          <h2 id="onboarding-step-title">Welcome to ChurchScribe</h2>
+          <h2 id="onboarding-step-title">Welcome to Scriptoria</h2>
         </div>
         <button class="ghost-button" id="close-onboarding-button" type="submit">Close</button>
       </div>
@@ -482,7 +482,7 @@
         <button class="ghost-button" id="onboarding-back-button" type="button">Back</button>
         <div class="onboarding-progress" id="onboarding-progress" aria-live="polite"></div>
         <button class="ghost-button" id="onboarding-next-button" type="button">Next</button>
-        <button class="ghost-button primary-button is-hidden" id="onboarding-finish-button" type="button">Start using ChurchScribe</button>
+        <button class="ghost-button primary-button is-hidden" id="onboarding-finish-button" type="button">Start using Scriptoria</button>
       </div>
     </form>
   </dialog>
@@ -501,7 +501,7 @@
     <div class="dialog-shell compact-shell">
       <div class="dialog-header">
         <div>
-          <p class="panel-kicker">Auxiliary Storage</p>
+          <p class="panel-kicker">Sync &amp; Backup</p>
           <h2 id="conflict-dialog-title">Sync Conflict Detected</h2>
         </div>
       </div>
@@ -524,16 +524,16 @@
         </div>
         <div class="first-sync-actions" id="first-sync-actions">
           <button class="first-sync-option" id="first-sync-keep-local-button" type="button">
-            <strong class="first-sync-option-title">Upload My Workspace</strong>
-            <span class="first-sync-option-desc">Replace the cloud workspace with your local data. The existing cloud workspace will be permanently overwritten.</span>
+            <strong class="first-sync-option-title">Upload My Library</strong>
+            <span class="first-sync-option-desc">Replace the cloud library with your local data. The existing cloud library will be permanently overwritten.</span>
           </button>
           <button class="first-sync-option" id="first-sync-use-cloud-button" type="button">
-            <strong class="first-sync-option-title">Download Cloud Workspace</strong>
-            <span class="first-sync-option-desc">Replace your local workspace with the data stored in the cloud. Your local workspace will be permanently overwritten.</span>
+            <strong class="first-sync-option-title">Download Cloud Library</strong>
+            <span class="first-sync-option-desc">Replace your local library with the data stored in the cloud. Your local library will be permanently overwritten.</span>
           </button>
           <button class="first-sync-option first-sync-option--cancel" id="first-sync-cancel-button" type="button">
             <strong class="first-sync-option-title">Not Now</strong>
-            <span class="first-sync-option-desc">Keep both workspaces unchanged. The external storage account will not be connected, and no syncing will occur. You can set this up later from Settings.</span>
+            <span class="first-sync-option-desc">Keep both libraries unchanged. The external storage account will not be connected, and no syncing will occur. You can set this up later from Settings.</span>
           </button>
         </div>
       </div>

--- a/storage/gdrive.js
+++ b/storage/gdrive.js
@@ -1,5 +1,5 @@
 /**
- * Google Drive cloud storage provider for ChurchScribe.
+ * Google Drive cloud storage provider for Scriptoria.
  *
  * Exposes window.GoogleDriveProvider, which implements the StorageProvider interface.
  * To add a new provider, create a new script that assigns an object with the same
@@ -77,7 +77,7 @@
  *     Returns the parsed data (null if no file exists yet) and the identifiers.
  *
  *   clearRemote(): Promise<void>
- *     Deletes all ChurchScribe files from the remote storage location.
+ *     Deletes all Scriptoria files from the remote storage location.
  *     Throws if no active session exists or if the deletion fails.
  *
  * ProviderSettings:

--- a/storage/localdrive.js
+++ b/storage/localdrive.js
@@ -1,5 +1,5 @@
 /**
- * Local Drive storage provider for ChurchScribe.
+ * Local Drive storage provider for Scriptoria.
  *
  * Exposes window.LocalDriveProvider, which implements the StorageProvider interface.
  * Uses the File System Access API to read/write a settings file plus one file per

--- a/storage/nullprovider.js
+++ b/storage/nullprovider.js
@@ -1,5 +1,5 @@
 /**
- * Null auxiliary storage provider for ChurchScribe.
+ * Null sync &amp; backup provider for Scriptoria.
  *
  * Exposes window.NullProvider, which implements the StorageProvider interface.
  * This provider performs no operations and is the default selection for users

--- a/storage/onedrive.js
+++ b/storage/onedrive.js
@@ -1,5 +1,5 @@
 /**
- * OneDrive cloud storage provider for ChurchScribe.
+ * OneDrive cloud storage provider for Scriptoria.
  *
  * Exposes window.OneDriveProvider, which implements the StorageProvider interface.
  * Uses MSAL.js (loaded from CDN) for OAuth 2.0 authentication with Microsoft
@@ -14,13 +14,13 @@
  *
  *  1. Visit https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade
  *  2. Click "New registration".
- *  3. Name: ChurchScribe (or any name you prefer).
+ *  3. Name: Scriptoria (or any name you prefer).
  *  4. Supported account types: choose
  *       "Accounts in any organizational directory (Any Azure AD directory –
  *        Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)"
  *     so that personal OneDrive accounts (Outlook.com / Hotmail / Live) work too.
  *  5. Redirect URI platform: "Single-page application (SPA)".
- *     Redirect URI value: the exact origin + path where ChurchScribe is hosted,
+ *     Redirect URI value: the exact origin + path where Scriptoria is hosted,
  *     e.g. https://yoursite.example.com/index.html  or  http://localhost/index.html
  *     (Add every URL you deploy to; you can add more later under
  *      Authentication → "Single-page application" → "Add URI".)


### PR DESCRIPTION
## Summary

- Renames the app from ChurchScribe to Scriptoria across all user-facing text
- Updates terminology: Notes → Entries, Note Types → Entry Types, Metadata → Details, Workspace → Library, Auxiliary Storage → Sync & Backup, Scripture Pane → Scripture Panel, Note Options → Entry Details, Browse Notes → Open Library
- Miscellaneous label improvements (editor placeholder, library search placeholder, Primary/Secondary Line → Library Title/Subtitle, Translations tab → Bible Translations, Data Management tab → Backup & Reset, Bible Verses → Scriptures)

## Backwards compatibility

- **Database**: Migrates data from `churchscribe-db` to `scriptoria-db` on first run if the new DB is empty. Old DB is left in place with a TODO for future removal.
- **Drag-and-drop**: Writes `application/x-scriptoria-embed`; accepts both old and new MIME types on drop. Old type retained with a TODO.
- **Backup files**: New exports use `scriptoria-backup` type and filename prefix. Old backup files continue to restore without any changes.

## Test plan

- [x] Existing users: verify data migrates from `churchscribe-db` to `scriptoria-db` on first load
- [x] Verify all renamed labels appear correctly in the UI (header, settings tabs, dialogs, onboarding)
- [x] Verify old backup files (with `churchscribe-backup` type) still restore successfully
- [x] Verify embed drag-and-drop still works within the editor
- [x] Verify Clear Local Library / Clear Remote Library confirmations use new wording
- [x] Verify new backup files download as `scriptoria-backup-YYYY-MM-DD.json`