### PR TITLE
Translations panel refactor: installed/available model (#128)

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,12 +52,12 @@ const providerSettingsContainer = document.querySelector("#provider-settings-con
 const googleConnectButton = document.querySelector("#google-connect-button");
 const googleDisconnectButton = document.querySelector("#google-disconnect-button");
 const googleSyncNowButton = document.querySelector("#google-sync-now-button");
-const downloadAllTranslationsButton = document.querySelector("#download-all-translations-button");
-const downloadAllTranslationsStatus = document.querySelector("#download-all-translations-status");
 const officialTranslationLanguageSearch = document.querySelector("#official-translation-language-search");
 const officialTranslationLanguageFilter = document.querySelector("#official-translation-language-filter");
 const clearOfficialLanguageFiltersButton = document.querySelector("#clear-official-language-filters-button");
-const officialTranslationList = document.querySelector("#official-translation-list");
+const availableTranslationSearch = document.querySelector("#available-translation-search");
+const availableTranslationList = document.querySelector("#available-translation-list");
+const installedTranslationList = document.querySelector("#installed-translation-list");
 const downloadBackupButton = document.querySelector("#download-backup-button");
 const restoreBackupButton = document.querySelector("#restore-backup-button");
 const restoreBackupFile = document.querySelector("#restore-backup-file");
@@ -1410,7 +1410,6 @@ settingsTabNav.addEventListener("click", (event) => {
 
 const translationFileInput = document.querySelector("#translation-file-input");
 const importTranslationFileButton = document.querySelector("#import-translation-file-button");
-const userTranslationList = document.querySelector("#user-translation-list");
 
 importTranslationFileButton.addEventListener("click", () => {
   translationFileInput.click();
@@ -1438,6 +1437,10 @@ translationFileInput.addEventListener("change", () => {
   });
 });
 
+availableTranslationSearch?.addEventListener("input", () => {
+  translationsManagerApiRef.setAvailableTranslationSearch(availableTranslationSearch.value);
+});
+
 officialTranslationLanguageSearch.addEventListener("input", () => {
   translationsManagerApiRef.setOfficialLanguageSearch(officialTranslationLanguageSearch.value);
   void renderTranslationsPanel();
@@ -1449,13 +1452,14 @@ officialTranslationLanguageFilter.addEventListener("change", () => {
 });
 
 clearOfficialLanguageFiltersButton.addEventListener("click", () => {
-  officialTranslationLanguageFilter.selectedIndex = -1;
-  officialTranslationLanguageSearch.value = "";
-  translationsManagerApiRef.setOfficialLanguageSearch("");
+  if (availableTranslationSearch) {
+    availableTranslationSearch.value = "";
+  }
+  translationsManagerApiRef.setAvailableTranslationSearch("");
   void translationsManagerApiRef.clearOfficialLanguageFilters();
 });
 
-officialTranslationList.addEventListener("click", (event) => {
+availableTranslationList?.addEventListener("click", (event) => {
   const button = event.target.closest("[data-install-official-translation]");
 
   if (!button) {
@@ -1463,32 +1467,33 @@ officialTranslationList.addEventListener("click", (event) => {
   }
 
   button.disabled = true;
-  button.textContent = "Adding…";
+  button.textContent = "Installing…";
   const translationId = button.dataset.installOfficialTranslation;
 
   void translationsManagerApiRef.installOfficialTranslation(translationId).then(() => {
-    updateSaveStatus(`Translation "${translationId}" added successfully.`);
+    updateSaveStatus(`"${translationId}" installed.`);
     setTimeout(() => refreshSaveStatus(), 4000);
   }).catch((err) => {
-    window.alert(`Couldn't add translation: ${err.message}`);
+    window.alert(`Couldn't install translation: ${err.message}`);
   });
 });
 
-userTranslationList.addEventListener("click", (event) => {
-  const btn = event.target.closest("[data-delete-translation]");
+installedTranslationList?.addEventListener("click", (event) => {
+  const button = event.target.closest("[data-uninstall-translation]");
 
-  if (!btn) {
+  if (!button) {
     return;
   }
 
-  const translationId = btn.dataset.deleteTranslation;
+  const translationId = button.dataset.uninstallTranslation;
+  const label = translationLibrary[translationId]?.label ?? translationId;
 
   // eslint-disable-next-line no-alert
-  if (!window.confirm(`Delete the "${translationId}" translation? This cannot be undone.`)) {
+  if (!window.confirm(`Uninstall "${label}"? You can reinstall it from the Available list.`)) {
     return;
   }
 
-  void deleteCustomTranslation(translationId).then(() => renderTranslationsPanel());
+  void translationsManagerApiRef.uninstallTranslation(translationId);
 });
 
 
@@ -1689,15 +1694,13 @@ const translationsManagerApi = window.ScriptoriaModules.createTranslationsManage
   translationRegistryStorageKey,
   translationStorageKey,
   translationSelect,
-  downloadAllTranslationsButton,
-  downloadAllTranslationsStatus,
   getCurrentTranslationCode: () => viewerApi.getCurrentTranslationCode(),
   applyTranslation: (...args) => applyTranslation(...args),
   openOfficialTranslationsSettings: () => {
     activeSettingsTabId = "translations";
     renderSettings();
     openDialog(settingsDialog);
-    window.setTimeout(() => officialTranslationLanguageSearch?.focus(), 0);
+    window.setTimeout(() => availableTranslationSearch?.focus(), 0);
   }
 });
 
@@ -1716,8 +1719,6 @@ const {
   validateTranslationData,
   populateTranslationSelect,
   importTranslationFromFile,
-  deleteCustomTranslation,
-  refreshDownloadAllTranslationsUi,
   renderTranslationsPanel
 } = translationsManagerApi;
 
@@ -1979,7 +1980,6 @@ window.ScriptoriaModules.createConnectivityWatcher({
   windowObject: window,
   refreshSaveStatus: () => refreshSaveStatus(),
   populateTranslationSelect: () => populateTranslationSelect(),
-  refreshDownloadAllTranslationsUi: () => refreshDownloadAllTranslationsUi(),
   isSettingsOpen: () => settingsDialog.open,
   renderSettings: () => renderSettings(),
   consumeQueuedCloudSync: () => consumeQueuedCloudSync(),

--- a/core/connectivity.js
+++ b/core/connectivity.js
@@ -16,7 +16,6 @@ window.ScriptoriaModules.createConnectivityWatcher = (deps) => {
     windowObject,
     refreshSaveStatus,
     populateTranslationSelect,
-    refreshDownloadAllTranslationsUi,
     isSettingsOpen,
     renderSettings,
     consumeQueuedCloudSync,
@@ -30,7 +29,6 @@ window.ScriptoriaModules.createConnectivityWatcher = (deps) => {
     // Refresh the translation picker so any not-yet-downloaded translations
     // get greyed out (offline) or re-enabled (online).
     populateTranslationSelect();
-    refreshDownloadAllTranslationsUi();
     if (isSettingsOpen()) {
       renderSettings();
     }

--- a/index.html
+++ b/index.html
@@ -396,44 +396,33 @@
           <div class="note-switcher-header">
             <h3 id="translations-title">Bible Translations</h3>
           </div>
-          <p class="settings-copy">Manage built-in, official, and user-added Bible translations. Drop a <code>.json</code> translation package anywhere on the page to import it, or use the import button below.</p>
+          <p class="settings-copy">Manage your installed Bible translations. Drop a <code>.json</code> translation package anywhere on the page to import it, or use the import button below.</p>
 
           <div class="data-management-section">
-            <h4 class="data-section-title">Built-in Translations</h4>
-            <p class="settings-copy">Translations download automatically the first time you select them. Use the button below to grab them all now so the full set is available offline.</p>
-            <div class="dialog-actions translation-download-actions">
-              <button class="ghost-button" id="download-all-translations-button" type="button">Download all for offline use</button>
-              <span class="settings-copy download-all-translations-status" id="download-all-translations-status" aria-live="polite"></span>
-            </div>
-            <ul class="translation-list" id="builtin-translation-list"></ul>
+            <h4 class="data-section-title">Installed Translations</h4>
+            <p class="settings-copy translation-list-empty-note" id="installed-translations-empty-note" hidden>No translations are installed.</p>
+            <ul class="translation-list" id="installed-translation-list"></ul>
           </div>
 
           <div class="data-management-section">
-            <div class="note-switcher-header translation-discovery-header">
-              <h4 class="data-section-title">Official Translations</h4>
-            </div>
-            <p class="settings-copy">Browse the licensed catalog and add translations for offline use. Use the language filter to narrow the list before adding.</p>
+            <h4 class="data-section-title">Available Translations</h4>
+            <p class="settings-copy">Browse the licensed catalog and install translations for offline use.</p>
             <div class="translation-discovery-controls">
               <label class="field">
-                <span>Filter Languages</span>
-                <input id="official-translation-language-search" type="search" placeholder="Search languages">
+                <span>Search</span>
+                <input id="available-translation-search" type="search" placeholder="Search by name or abbreviation…">
               </label>
-              <label class="field">
-                <span>Selected Languages</span>
-                <select id="official-translation-language-filter" multiple size="8" aria-label="Official translation language filter"></select>
-              </label>
+              <div class="field translation-language-filter-group">
+                <span class="field-label">Filter by Language</span>
+                <div class="translation-language-pills" id="translation-language-pills" role="group" aria-label="Filter by language"></div>
+                <button class="ghost-button ghost-button--small" id="clear-official-language-filters-button" type="button">Clear</button>
+                <!-- Hidden select kept for existing event-handler compatibility -->
+                <select id="official-translation-language-filter" multiple hidden aria-hidden="true"></select>
+                <input id="official-translation-language-search" type="search" hidden aria-hidden="true">
+              </div>
             </div>
-            <div class="dialog-actions data-actions">
-              <button class="ghost-button" id="clear-official-language-filters-button" type="button">Clear Language Filters</button>
-            </div>
-            <p class="settings-copy translation-list-empty-note" id="official-translations-empty-note" hidden>No official translations match the current language filter.</p>
-            <ul class="translation-list" id="official-translation-list"></ul>
-          </div>
-
-          <div class="data-management-section" id="user-translations-section">
-            <h4 class="data-section-title">User-Added Translations</h4>
-            <p class="settings-copy" id="user-translations-empty-note">No user-added translations have been added yet.</p>
-            <ul class="translation-list" id="user-translation-list"></ul>
+            <p class="settings-copy translation-list-empty-note" id="available-translations-empty-note" hidden>No translations match the current search or language filter.</p>
+            <ul class="translation-list" id="available-translation-list"></ul>
           </div>
 
           <div class="data-management-section">

--- a/styles.css
+++ b/styles.css
@@ -1785,28 +1785,24 @@ h1 {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
+}
+
+#installed-translation-list {
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .translation-list-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--surface);
   box-sizing: border-box;
-  /* 3 columns with 8px gap: (8px * 2) / 3 columns = ~6px per item */
-  width: calc(33.333% - 6px);
-}
-
-#user-translation-list .translation-list-item {
-  /* 2 columns with 8px gap: 8px / 2 columns = 4px per item */
-  width: calc(50% - 4px);
 }
 
 .translation-list-item-info {
@@ -1866,13 +1862,48 @@ h1 {
 
 .translation-discovery-controls {
   display: grid;
-  grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.2fr);
-  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
   margin-bottom: 12px;
+  align-items: start;
 }
 
-#official-translation-language-filter {
-  min-height: 180px;
+.translation-language-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.translation-language-filter-group .field-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.translation-language-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.translation-language-pill {
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.translation-language-pill:hover {
+  border-color: var(--accent, var(--primary));
+}
+
+.translation-language-pill[aria-pressed="true"] {
+  background: var(--accent, var(--primary));
+  border-color: var(--accent, var(--primary));
+  color: var(--on-accent, #fff);
 }
 
 .translation-list-empty-note {
@@ -1886,6 +1917,11 @@ h1 {
 .translation-list-item--actionable .translation-list-item-info {
   width: auto;
   flex: 1;
+}
+
+.translation-list-item--actionable > button {
+  align-self: flex-start;
+  flex-shrink: 0;
 }
 
 .ghost-button--small {

--- a/translations/manager.js
+++ b/translations/manager.js
@@ -9,8 +9,6 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     translationRegistryStorageKey,
     translationStorageKey,
     translationSelect,
-    downloadAllTranslationsButton,
-    downloadAllTranslationsStatus,
     getCurrentTranslationCode,
     applyTranslation,
     openOfficialTranslationsSettings
@@ -26,11 +24,11 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
 
   const offlineAvailableTranslations = new Set();
 
-  let downloadAllTranslationsInFlight = false;
   let catalogIndex = null;
   let translationRegistry = null;
   let officialLanguageSearch = "";
   let officialLanguageFilters = new Set();
+  let availableTranslationSearch = "";
   const catalogEntries = new Map();
   const loadedLanguageTags = new Set();
 
@@ -111,7 +109,7 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
       .sort((a, b) => (a.label ?? a.code).localeCompare(b.label ?? b.code, undefined, { sensitivity: "base" }));
 
   const getDefaultTranslationId = () =>
-    catalogIndex?.defaultBuiltinIds?.[0]
+    Object.keys(translationRegistry?.installedTranslations ?? {})[0]
     ?? Object.keys(translationLibrary)[0]
     ?? "en:KJV";
 
@@ -205,18 +203,14 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     translationRegistry = normalizeTranslationRegistry(await readStoredValue(translationRegistryStorageKey));
   };
 
-  // Migration: any previously-bundled bible the user had downloaded is recorded in
-  // installedTranslations with sourceType "builtin". Now that only KJV is bundled,
-  // those entries must become "official" so they stay visible in the selector.
-  // This is naturally idempotent — once promoted there are no "builtin" entries left
-  // (other than KJV, which remains bundled and is skipped).
+  // Migration: any translation recorded in installedTranslations with sourceType "builtin"
+  // must become "official" so it stays visible and consistent with the new unified model.
+  // This is naturally idempotent — once promoted there are no "builtin" entries left.
   // TODO: Remove this function and its call in initializeTranslations once enough time
   // has passed that no user would still have un-migrated "builtin" entries (~November 2026).
   const migrateBuiltinBibles = async () => {
     const entries = Object.entries(translationRegistry.installedTranslations);
-    const toPromote = entries.filter(
-      ([translationId, record]) => record.sourceType === BUILTIN_SOURCE_TYPE && translationId !== "en:KJV"
-    );
+    const toPromote = entries.filter(([, record]) => record.sourceType === BUILTIN_SOURCE_TYPE);
 
     if (toPromote.length === 0) {
       return;
@@ -224,7 +218,7 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
 
     for (const [translationId, record] of toPromote) {
       record.sourceType = OFFICIAL_SOURCE_TYPE;
-      console.info(`[Migration] Promoted "${translationId}" from builtin to Added bible.`);
+      console.info(`[Migration] Promoted "${translationId}" from builtin to official.`);
     }
 
     await persistTranslationRegistry();
@@ -291,12 +285,8 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     await Promise.all(languageTags.map((languageTag) => ensureLanguageCatalogLoaded(languageTag)));
   };
 
-  const getVisibleTranslationIds = () => {
-    const builtinIds = catalogIndex?.defaultBuiltinIds ?? [];
-    const officialIds = getInstalledOfficialIds();
-    const userIds = Object.keys(translationRegistry?.userTranslations ?? {});
-    return [...new Set([...builtinIds, ...officialIds, ...userIds])];
-  };
+  const getVisibleTranslationIds = () =>
+    Object.keys(translationRegistry?.installedTranslations ?? {});
 
   const rebuildTranslationLibrary = () => {
     const visibleIds = new Set(getVisibleTranslationIds());
@@ -348,8 +338,14 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     translationLibrary[translationId] ?? catalogEntries.get(translationId) ?? null;
 
   const writeInstalledRecord = async (translationId, entry, contentHash = null) => {
+    // Normalize builtin → official so the registry is always consistent.
+    // The "builtin" sourceType is a catalog/builder concept only; in the installed
+    // registry every catalog-sourced translation is "official".
+    const sourceType = entry.sourceType === BUILTIN_SOURCE_TYPE
+      ? OFFICIAL_SOURCE_TYPE
+      : entry.sourceType;
     translationRegistry.installedTranslations[translationId] = {
-      sourceType: entry.sourceType,
+      sourceType,
       version: entry.version,
       installedAt: new Date().toISOString(),
       contentHash
@@ -492,121 +488,35 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     }
   };
 
-  const refreshDownloadAllTranslationsUi = () => {
-    if (!downloadAllTranslationsButton || !downloadAllTranslationsStatus) {
-      return;
-    }
-
-    const builtinIds = catalogIndex?.defaultBuiltinIds ?? [];
-    const missing = builtinIds.filter((translationId) => !offlineAvailableTranslations.has(translationId));
-    const offline = !navigator.onLine;
-
-    if (downloadAllTranslationsInFlight) {
-      return;
-    }
-
-    if (missing.length === 0) {
-      downloadAllTranslationsButton.disabled = true;
-      downloadAllTranslationsButton.textContent = "All downloaded";
-      downloadAllTranslationsStatus.textContent = `${builtinIds.length} of ${builtinIds.length} available offline.`;
-      return;
-    }
-
-    downloadAllTranslationsButton.textContent = "Download all for offline use";
-
-    if (offline) {
-      downloadAllTranslationsButton.disabled = true;
-      downloadAllTranslationsStatus.textContent = `You're offline — ${missing.length} of ${builtinIds.length} not yet downloaded. Reconnect to download the rest.`;
-      return;
-    }
-
-    downloadAllTranslationsButton.disabled = false;
-    downloadAllTranslationsStatus.textContent = `${builtinIds.length - missing.length} of ${builtinIds.length} available offline.`;
-  };
-
-  const downloadAllBuiltinTranslations = async () => {
-    if (downloadAllTranslationsInFlight) {
-      return;
-    }
-
-    if (!navigator.onLine) {
-      if (downloadAllTranslationsStatus) {
-        downloadAllTranslationsStatus.textContent = "You're offline — connect to download.";
-      }
-      return;
-    }
-
-    const builtinIds = catalogIndex?.defaultBuiltinIds ?? [];
-    const missing = builtinIds.filter((translationId) => !offlineAvailableTranslations.has(translationId));
-
-    if (missing.length === 0) {
-      return;
-    }
-
-    downloadAllTranslationsInFlight = true;
-
-    if (downloadAllTranslationsButton) {
-      downloadAllTranslationsButton.disabled = true;
-    }
-
-    let succeeded = 0;
-    let failed = 0;
-
-    for (let index = 0; index < missing.length; index += 1) {
-      const translationId = missing[index];
-      const entry = getTranslationEntry(translationId);
-
-      if (downloadAllTranslationsButton) {
-        downloadAllTranslationsButton.textContent = `Downloading ${index + 1} of ${missing.length}…`;
-      }
-
-      if (downloadAllTranslationsStatus) {
-        downloadAllTranslationsStatus.textContent = `Downloading ${entry?.label ?? translationId}…`;
-      }
-
-      try {
-        await ensureTranslationLoaded(translationId);
-        succeeded += 1;
-      } catch (error) {
-        console.warn(`[Translation] Bulk download failed for "${translationId}":`, error);
-        failed += 1;
-      }
-    }
-
-    downloadAllTranslationsInFlight = false;
-    populateTranslationSelect();
-    renderTranslationsPanel();
-
-    if (downloadAllTranslationsStatus) {
-      downloadAllTranslationsStatus.textContent = failed === 0
-        ? `Downloaded ${succeeded} translation${succeeded === 1 ? "" : "s"}. All available offline.`
-        : `Downloaded ${succeeded}, failed ${failed}. Click again to retry.`;
-    }
-
-    refreshDownloadAllTranslationsUi();
-  };
 
   const renderOfficialLanguageOptions = () => {
-    const select = document.querySelector("#official-translation-language-filter");
-
-    if (!select) {
+    const pillsContainer = document.querySelector("#translation-language-pills");
+    if (!pillsContainer) {
       return;
     }
 
-    const search = officialLanguageSearch.trim().toLowerCase();
-    const languages = getCatalogLanguageEntries().filter((entry) =>
-      !search
-      || entry.displayName.toLowerCase().includes(search)
-      || entry.languageTag.toLowerCase().includes(search)
-    );
+    const languages = getCatalogLanguageEntries();
+    pillsContainer.innerHTML = "";
 
-    select.innerHTML = "";
     languages.forEach((entry) => {
-      const option = document.createElement("option");
-      option.value = entry.languageTag;
-      option.textContent = `${entry.displayName} (${entry.languageTag})`;
-      option.selected = officialLanguageFilters.has(entry.languageTag);
-      select.append(option);
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "translation-language-pill";
+      button.textContent = entry.displayName;
+      button.dataset.languageTag = entry.languageTag;
+      button.setAttribute("aria-pressed", officialLanguageFilters.has(entry.languageTag) ? "true" : "false");
+
+      button.addEventListener("click", () => {
+        if (officialLanguageFilters.has(entry.languageTag)) {
+          officialLanguageFilters.delete(entry.languageTag);
+        } else {
+          officialLanguageFilters.add(entry.languageTag);
+        }
+        button.setAttribute("aria-pressed", officialLanguageFilters.has(entry.languageTag) ? "true" : "false");
+        void renderTranslationsPanel();
+      });
+
+      pillsContainer.append(button);
     });
   };
 
@@ -617,77 +527,43 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
 
     await Promise.all(selectedTags.map((languageTag) => ensureLanguageCatalogLoaded(languageTag)));
 
+    const search = availableTranslationSearch.trim().toLowerCase();
+
     return [...catalogEntries.values()]
-      .filter((entry) => entry.sourceType === OFFICIAL_SOURCE_TYPE)
+      .filter((entry) => entry.sourceType === OFFICIAL_SOURCE_TYPE || entry.sourceType === BUILTIN_SOURCE_TYPE)
       .filter((entry) => selectedTags.includes(entry.languageTag))
+      .filter((entry) => !getInstalledTranslations()[entry.translationId])
+      .filter((entry) =>
+        !search
+        || (entry.label ?? "").toLowerCase().includes(search)
+        || (entry.code ?? "").toLowerCase().includes(search)
+      )
       .sort((a, b) => (a.label ?? a.code).localeCompare(b.label ?? b.code, undefined, { sensitivity: "base" }));
   };
 
   const renderTranslationsPanel = async () => {
-    const builtinList = document.querySelector("#builtin-translation-list");
-    const officialList = document.querySelector("#official-translation-list");
-    const officialEmptyNote = document.querySelector("#official-translations-empty-note");
-    const userList = document.querySelector("#user-translation-list");
-    const userEmptyNote = document.querySelector("#user-translations-empty-note");
+    const installedList = document.querySelector("#installed-translation-list");
+    const installedEmptyNote = document.querySelector("#installed-translations-empty-note");
+    const availableList = document.querySelector("#available-translation-list");
+    const availableEmptyNote = document.querySelector("#available-translations-empty-note");
 
-    if (!builtinList || !officialList || !userList || !userEmptyNote) {
+    if (!installedList || !availableList) {
       return;
     }
 
     renderOfficialLanguageOptions();
 
-    builtinList.innerHTML = "";
-    (catalogIndex?.defaultBuiltinIds ?? [])
-      .map((translationId) => getTranslationEntry(translationId))
-      .filter(Boolean)
-      .sort((a, b) => (a.label ?? a.code).localeCompare(b.label ?? b.code, undefined, { sensitivity: "base" }))
-      .forEach((entry) => {
-        const li = document.createElement("li");
-        li.className = "translation-list-item";
+    // ── Installed ────────────────────────────────────────────────────────────
+    installedList.innerHTML = "";
+    const installedEntries = Object.values(translationLibrary)
+      .sort((a, b) => (a.label ?? a.code).localeCompare(b.label ?? b.code, undefined, { sensitivity: "base" }));
+    const onlyOne = installedEntries.length === 1;
 
-        const info = document.createElement("span");
-        info.className = "translation-list-item-info";
-
-        const codeEl = document.createElement("span");
-        codeEl.className = "translation-list-item-code";
-        codeEl.textContent = entry.code;
-
-        const labelEl = document.createElement("span");
-        labelEl.className = "translation-list-item-label";
-        labelEl.textContent = entry.label;
-
-        const tag = document.createElement("span");
-        tag.className = "translation-list-item-tag";
-
-        if (entry.hasUpdate) {
-          tag.textContent = "Update available";
-          tag.dataset.state = "missing";
-        } else if (offlineAvailableTranslations.has(entry.translationId)) {
-          tag.textContent = "Downloaded";
-          tag.dataset.state = "downloaded";
-        } else {
-          tag.textContent = "Not downloaded";
-          tag.dataset.state = "missing";
-        }
-
-        const header = document.createElement("span");
-        header.className = "translation-list-item-header";
-        header.append(codeEl, tag);
-        info.append(header, labelEl);
-        li.append(info);
-        builtinList.append(li);
-      });
-
-    refreshDownloadAllTranslationsUi();
-
-    officialList.innerHTML = "";
-    const officialEntries = await getOfficialDiscoveryEntries();
-
-    if (officialEmptyNote) {
-      officialEmptyNote.hidden = officialEntries.length > 0;
+    if (installedEmptyNote) {
+      installedEmptyNote.hidden = installedEntries.length > 0;
     }
 
-    officialEntries.forEach((entry) => {
+    installedEntries.forEach((entry) => {
       const li = document.createElement("li");
       li.className = "translation-list-item translation-list-item--actionable";
 
@@ -700,45 +576,40 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
 
       const labelEl = document.createElement("span");
       labelEl.className = "translation-list-item-label";
-      labelEl.textContent = `${entry.label} (${entry.languageTag})`;
-
-      const tag = document.createElement("span");
-      tag.className = "translation-list-item-tag";
-
-      if (entry.hasUpdate) {
-        tag.textContent = "Update available";
-        tag.dataset.state = "missing";
-      } else if (getInstalledTranslations()[entry.translationId]) {
-        tag.textContent = "Added";
-        tag.dataset.state = "downloaded";
-      } else {
-        tag.textContent = "Available";
-        tag.dataset.state = "available";
-      }
+      labelEl.textContent = entry.languageTag
+        ? `${entry.label ?? entry.code} (${entry.languageTag})`
+        : (entry.label ?? entry.code);
 
       const header = document.createElement("span");
       header.className = "translation-list-item-header";
-      header.append(codeEl, tag);
+      header.append(codeEl);
+      info.append(header, labelEl);
 
       const button = document.createElement("button");
       button.type = "button";
-      button.className = "ghost-button ghost-button--small";
-      button.dataset.installOfficialTranslation = entry.translationId;
-      button.textContent = getInstalledTranslations()[entry.translationId] ? (entry.hasUpdate ? "Update" : "Added") : "Add";
-      button.disabled = !!getInstalledTranslations()[entry.translationId] && !entry.hasUpdate;
+      button.className = "ghost-button ghost-button--danger ghost-button--small";
+      button.dataset.uninstallTranslation = entry.translationId;
+      button.textContent = "Uninstall";
+      button.disabled = onlyOne;
+      if (onlyOne) {
+        button.title = "You must have at least one translation installed.";
+      }
 
-      info.append(header, labelEl);
       li.append(info, button);
-      officialList.append(li);
+      installedList.append(li);
     });
 
-    userList.innerHTML = "";
-    const userTranslations = getUserTranslations();
-    userEmptyNote.hidden = userTranslations.length > 0;
+    // ── Available ─────────────────────────────────────────────────────────────
+    availableList.innerHTML = "";
+    const availableEntries = await getOfficialDiscoveryEntries();
 
-    userTranslations.forEach((entry) => {
+    if (availableEmptyNote) {
+      availableEmptyNote.hidden = availableEntries.length > 0;
+    }
+
+    availableEntries.forEach((entry) => {
       const li = document.createElement("li");
-      li.className = "translation-list-item";
+      li.className = "translation-list-item translation-list-item--actionable";
 
       const info = document.createElement("span");
       info.className = "translation-list-item-info";
@@ -749,17 +620,21 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
 
       const labelEl = document.createElement("span");
       labelEl.className = "translation-list-item-label";
-      labelEl.textContent = `${entry.label} (${entry.languageTag})`;
+      labelEl.textContent = `${entry.label ?? entry.code} (${entry.languageTag})`;
+
+      const header = document.createElement("span");
+      header.className = "translation-list-item-header";
+      header.append(codeEl);
+      info.append(header, labelEl);
 
       const button = document.createElement("button");
       button.type = "button";
-      button.className = "ghost-button ghost-button--danger ghost-button--small";
-      button.dataset.deleteTranslation = entry.translationId;
-      button.textContent = "Delete";
+      button.className = "ghost-button ghost-button--small";
+      button.dataset.installOfficialTranslation = entry.translationId;
+      button.textContent = "Install";
 
-      info.append(codeEl, labelEl);
       li.append(info, button);
-      userList.append(li);
+      availableList.append(li);
     });
   };
 
@@ -836,7 +711,7 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     const translationPackage = buildUserTranslationPackage(rawPackage);
     const { manifest, content } = translationPackage;
 
-    if (catalogEntries.has(manifest.translationId) || (catalogIndex?.defaultBuiltinIds ?? []).includes(manifest.translationId)) {
+    if (catalogEntries.has(manifest.translationId)) {
       throw new Error(`"${manifest.translationId}" is already defined by the catalog.`);
     }
 
@@ -857,29 +732,34 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     return manifest.translationId;
   };
 
-  const deleteCustomTranslation = async (translationId) => {
-    if (!translationRegistry.userTranslations[translationId]) {
+  const uninstallTranslation = async (translationId) => {
+    // Guard: never allow removing the last installed translation.
+    if (Object.keys(translationRegistry.installedTranslations).length <= 1) {
       return;
     }
 
-    delete translationRegistry.userTranslations[translationId];
+    const isUserTranslation = !!translationRegistry.userTranslations[translationId];
+    if (isUserTranslation) {
+      delete translationRegistry.userTranslations[translationId];
+    }
     delete translationRegistry.installedTranslations[translationId];
     delete translationLibrary[translationId];
+
     await deleteStoredValue(`${translationContentCacheKeyPrefix}${translationId}`);
     await deleteStoredValue(`${translationManifestCacheKeyPrefix}${translationId}`);
     await persistTranslationRegistry();
 
-    const fallbackTranslationId = getDefaultTranslationId();
-
     if (getCurrentTranslationCode() === translationId) {
-      await applyTranslation(fallbackTranslationId);
-      await writeStoredValue(translationStorageKey, fallbackTranslationId);
-      await markRegistrySelection(fallbackTranslationId);
+      const fallback = getDefaultTranslationId();
+      await applyTranslation(fallback);
+      await writeStoredValue(translationStorageKey, fallback);
+      await markRegistrySelection(fallback);
     }
 
     rebuildTranslationLibrary();
     await refreshOfflineTranslationAvailability();
     populateTranslationSelect();
+    await renderTranslationsPanel();
   };
 
   const setOfficialLanguageSearch = (value) => {
@@ -894,6 +774,11 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
   const clearOfficialLanguageFilters = async () => {
     officialLanguageFilters = new Set();
     await renderTranslationsPanel();
+  };
+
+  const setAvailableTranslationSearch = (value) => {
+    availableTranslationSearch = typeof value === "string" ? value.trim().toLowerCase() : "";
+    void renderTranslationsPanel();
   };
 
   const handleTranslationSelection = async (translationId) => {
@@ -934,10 +819,7 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
       ? translationState.installedOfficialIds.filter((translationId) => typeof translationId === "string")
       : [];
 
-    await ensureCatalogEntriesLoaded([
-      ...(catalogIndex?.defaultBuiltinIds ?? []),
-      ...officialIds
-    ]);
+    await ensureCatalogEntriesLoaded(officialIds);
 
     const nextInstalledTranslations = {};
 
@@ -1011,25 +893,26 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     await persistTranslationRegistry();
   };
 
-  // TODO: Remove migrateBuiltinBibles and the PREVIOUSLY_BUNDLED_IDS / MIGRATION_BUNDLED_TO_OFFICIAL
-  // constants once enough time has passed that no user would still have the old bundled bibles
-  // in their cache without having run the migration (~November 2026).
+  // Auto-installs KJV for first-time users (installedTranslations empty after migration).
+  // Does nothing if at least one translation is already installed.
+  const autoInstallDefaultTranslation = async () => {
+    if (Object.keys(translationRegistry.installedTranslations).length === 0) {
+      await ensureCatalogEntriesLoaded(["en:KJV"]);
+      await ensureTranslationLoaded("en:KJV");
+      console.info("[Init] Auto-installed KJV as default translation.");
+    }
+  };
+
+  // TODO: Remove migrateBuiltinBibles once enough time has passed that no user
+  // would still have un-migrated "builtin" entries (~November 2026).
   const initializeTranslations = async () => {
     await loadTranslationRegistry();
     await migrateBuiltinBibles();
+    await autoInstallDefaultTranslation();
     await ensureCatalogIndexLoaded();
-    await ensureCatalogEntriesLoaded([
-      ...(catalogIndex?.defaultBuiltinIds ?? []),
-      ...getInstalledOfficialIds()
-    ]);
+    await ensureCatalogEntriesLoaded(getInstalledOfficialIds());
     rebuildTranslationLibrary();
   };
-
-  if (downloadAllTranslationsButton) {
-    downloadAllTranslationsButton.addEventListener("click", () => {
-      void downloadAllBuiltinTranslations();
-    });
-  }
 
   return {
     GET_MORE_TRANSLATIONS_VALUE,
@@ -1041,14 +924,13 @@ window.ScriptoriaModules.createTranslationsManager = (deps) => {
     populateTranslationSelect,
     renderTranslationsPanel,
     importTranslationFromFile,
-    deleteCustomTranslation,
+    uninstallTranslation,
     installOfficialTranslation,
     setOfficialLanguageSearch,
     setOfficialLanguageFilters,
     clearOfficialLanguageFilters,
+    setAvailableTranslationSearch,
     handleTranslationSelection,
-    downloadAllBuiltinTranslations,
-    refreshDownloadAllTranslationsUi,
     getDefaultTranslationId,
     getInstalledOfficialIds,
     getTranslationStateForBackup,


### PR DESCRIPTION
Closes #128

Replaces the three-section Builtin/Official/User-Added translations panel with a unified Installed/Available model.

- KJV auto-installs on first run; if uninstalled it stays uninstalled
- All installed translations (catalog and user-imported) live in one sorted list with an Uninstall button
- Uninstall is blocked when only one translation remains
- Available list is searchable by name/abbreviation and filterable by language via pill toggles
- Removed "Download all" button and builtin/official distinction from the UI
- Registry sourceType normalized: "builtin" → "official" on install going forward; migration promotes any existing "builtin" entries
- Fixes leading slash bug in generated catalog URLs (#126)